### PR TITLE
feat: add history management, article reader, and video quality controls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,9 @@ repos:
     rev: v1.2.1
     hooks:
       - id: build
-        stages: [push]
+        stages: [pre-push]
         name: Cargo Build
 
       - id: test
-        stages: [push]
+        stages: [pre-push]
         name: Cargo Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "ratatui",
  "ratatui-image",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "tokio",
@@ -392,6 +393,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -723,6 +730,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,10 +944,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1137,6 +1188,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1266,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1316,6 +1395,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever",
+ "match_token",
+]
 
 [[package]]
 name = "http"
@@ -1882,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1985,28 @@ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
  "nix",
  "winapi",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2445,6 +2563,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -3266,6 +3390,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3425,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3362,6 +3520,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3504,6 +3671,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,6 +3808,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4136,6 +4339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,6 +4520,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ratatui-image = { version = "11.0.2", default-features = false, features = ["ima
 reqwest = { version = "0.13.2", features = ["json", "cookies", "form"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+scraper = "0.24.0"
 tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 tokio-tungstenite = { version = "0.29.0", features = ["native-tls"] }

--- a/src/api/article.rs
+++ b/src/api/article.rs
@@ -1,0 +1,375 @@
+//! Article response models and normalization for terminal rendering.
+
+use scraper::{Html, Selector};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ArticleData {
+    #[serde(default)]
+    pub id: i64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default, deserialize_with = "deserialize_content")]
+    pub content: String,
+    #[serde(default, rename = "type")]
+    pub article_type: i32,
+    #[serde(default)]
+    pub author: Option<ArticleAuthor>,
+    #[serde(default)]
+    pub publish_time: i64,
+    #[serde(default)]
+    pub image_urls: Vec<String>,
+    #[serde(default)]
+    pub origin_image_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ArticleAuthor {
+    #[serde(default)]
+    pub mid: i64,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArticleDocument {
+    pub body: String,
+    pub image_urls: Vec<String>,
+    pub blocks: Vec<ArticleBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArticleBlock {
+    Text(String),
+    Image { url: String, alt: String },
+    Embedded(String),
+}
+
+fn deserialize_content<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::Null => Ok(String::new()),
+        serde_json::Value::String(content) => Ok(content),
+        value => serde_json::to_string(&value).map_err(serde::de::Error::custom),
+    }
+}
+
+impl ArticleData {
+    pub fn document(&self) -> ArticleDocument {
+        let mut document = if self.article_type == 3 || self.content.trim_start().starts_with('{') {
+            document_from_json(&self.content)
+        } else {
+            document_from_html(&self.content)
+        };
+
+        for url in self.image_urls.iter().chain(self.origin_image_urls.iter()) {
+            let url = normalized_url(url);
+            if !url.is_empty() && !document.image_urls.contains(&url) {
+                document.image_urls.push(url.clone());
+                document.blocks.push(ArticleBlock::Image {
+                    url,
+                    alt: "文章图片".to_string(),
+                });
+            }
+        }
+        if document.blocks.is_empty() && !self.summary.trim().is_empty() {
+            document
+                .blocks
+                .push(ArticleBlock::Text(self.summary.clone()));
+        }
+        document.body = document_body(&document.blocks);
+        document
+    }
+}
+
+fn document_from_html(content: &str) -> ArticleDocument {
+    let html = Html::parse_fragment(content);
+    let blocks = Selector::parse("h1,h2,h3,h4,p,blockquote,li,pre,figure,img").expect("selector");
+    let images = Selector::parse("img").expect("selector");
+    let links = Selector::parse("a[href]").expect("selector");
+    let mut document_blocks = Vec::new();
+    let mut image_urls = Vec::new();
+
+    for element in html.select(&blocks) {
+        let name = element.value().name();
+        if name == "figure" {
+            if let Some(image) = element.select(&images).next() {
+                if let Some(placeholder) = embedded_placeholder(&image) {
+                    document_blocks.push(ArticleBlock::Embedded(placeholder));
+                } else if let Some(url) = image_url(&image) {
+                    push_unique_url(&mut image_urls, &url);
+                    document_blocks.push(ArticleBlock::Image {
+                        url: normalized_url(&url),
+                        alt: image.value().attr("alt").unwrap_or("文章图片").to_string(),
+                    });
+                }
+            }
+            continue;
+        }
+        if name == "img" {
+            let inside_figure = element.ancestors().any(|node| {
+                scraper::ElementRef::wrap(node)
+                    .is_some_and(|parent| parent.value().name() == "figure")
+            });
+            if inside_figure {
+                continue;
+            }
+            if let Some(placeholder) = embedded_placeholder(&element) {
+                document_blocks.push(ArticleBlock::Embedded(placeholder));
+            } else if let Some(url) = image_url(&element) {
+                push_unique_url(&mut image_urls, &url);
+                document_blocks.push(ArticleBlock::Image {
+                    url: normalized_url(&url),
+                    alt: element
+                        .value()
+                        .attr("alt")
+                        .unwrap_or("文章图片")
+                        .to_string(),
+                });
+            }
+            continue;
+        }
+
+        let text = element.text().collect::<Vec<_>>().join("");
+        let text = text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        let mut line = match name {
+            "h1" | "h2" | "h3" | "h4" => format!("# {text}"),
+            "blockquote" => format!("> {text}"),
+            "li" => format!("• {text}"),
+            "pre" => format!("```\n{text}\n```"),
+            _ => text.to_string(),
+        };
+        for link in element.select(&links) {
+            if let Some(href) = link.value().attr("href")
+                && !href.is_empty()
+            {
+                line.push_str(&format!(" ({href})"));
+            }
+        }
+        document_blocks.push(ArticleBlock::Text(line));
+    }
+
+    if document_blocks.is_empty() {
+        let text = html.root_element().text().collect::<Vec<_>>().join("");
+        if !text.trim().is_empty() {
+            document_blocks.push(ArticleBlock::Text(text.trim().to_string()));
+        }
+    }
+
+    ArticleDocument {
+        body: document_body(&document_blocks),
+        image_urls,
+        blocks: document_blocks,
+    }
+}
+
+fn document_from_json(content: &str) -> ArticleDocument {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        let blocks = vec![ArticleBlock::Text(content.to_string())];
+        return ArticleDocument {
+            body: content.to_string(),
+            image_urls: Vec::new(),
+            blocks,
+        };
+    };
+    let mut blocks = Vec::new();
+    let mut image_urls = Vec::new();
+    for operation in value
+        .get("ops")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some(insert) = operation.get("insert") else {
+            continue;
+        };
+        if let Some(text) = insert.as_str() {
+            push_text_block(&mut blocks, text);
+            continue;
+        }
+        let Some(object) = insert.as_object() else {
+            continue;
+        };
+        if let Some(image) = object.get("native-image") {
+            if let Some(url) = image.get("url").and_then(serde_json::Value::as_str) {
+                push_unique_url(&mut image_urls, url);
+                blocks.push(ArticleBlock::Image {
+                    url: normalized_url(url),
+                    alt: image
+                        .get("alt")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("文章图片")
+                        .to_string(),
+                });
+            }
+        } else if let Some(card) = object.get("video-card") {
+            push_json_card(&mut blocks, "视频", card);
+        } else if let Some(card) = object.get("article-card") {
+            push_json_card(&mut blocks, "文章", card);
+        } else if let Some(card) = object.get("live-card") {
+            push_json_card(&mut blocks, "直播", card);
+        } else if let Some(card) = object.get("vote-card") {
+            push_json_card(&mut blocks, "投票", card);
+        } else if object.contains_key("cut-off") {
+            blocks.push(ArticleBlock::Embedded("────────".to_string()));
+        }
+    }
+    ArticleDocument {
+        body: document_body(&blocks),
+        image_urls,
+        blocks,
+    }
+}
+
+fn push_json_card(blocks: &mut Vec<ArticleBlock>, label: &str, card: &serde_json::Value) {
+    let id = card
+        .get("id")
+        .and_then(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .or_else(|| value.as_i64().map(|v| v.to_string()))
+        })
+        .unwrap_or_default();
+    blocks.push(ArticleBlock::Embedded(format!("[{label} {id}]")));
+}
+
+fn push_text_block(blocks: &mut Vec<ArticleBlock>, text: &str) {
+    if let Some(ArticleBlock::Text(previous)) = blocks.last_mut() {
+        previous.push_str(text);
+    } else {
+        blocks.push(ArticleBlock::Text(text.to_string()));
+    }
+}
+
+fn document_body(blocks: &[ArticleBlock]) -> String {
+    let mut image_index = 0;
+    blocks
+        .iter()
+        .map(|block| match block {
+            ArticleBlock::Text(text) => text.trim().to_string(),
+            ArticleBlock::Image { .. } => {
+                image_index += 1;
+                format!("[图片 {image_index}]")
+            }
+            ArticleBlock::Embedded(text) => text.clone(),
+        })
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn embedded_placeholder(image: &scraper::ElementRef<'_>) -> Option<String> {
+    let classes = image.value().attr("class").unwrap_or_default();
+    let id = image
+        .value()
+        .attr("aid")
+        .or_else(|| image.value().attr("data-aid"))
+        .unwrap_or_default();
+    [
+        ("video-card", "视频"),
+        ("article-card", "文章"),
+        ("fanju-card", "番剧"),
+        ("live-card", "直播"),
+        ("music-card", "音乐"),
+        ("vote-card", "投票"),
+    ]
+    .into_iter()
+    .find_map(|(class, label)| classes.contains(class).then(|| format!("[{label} {id}]")))
+}
+
+fn image_url(image: &scraper::ElementRef<'_>) -> Option<String> {
+    image
+        .value()
+        .attr("data-src")
+        .or_else(|| image.value().attr("src"))
+        .filter(|url| !url.is_empty())
+        .map(str::to_owned)
+}
+
+fn push_unique_url(urls: &mut Vec<String>, url: &str) {
+    let normalized = normalized_url(url);
+    if !normalized.is_empty() && !urls.contains(&normalized) {
+        urls.push(normalized);
+    }
+}
+
+fn normalized_url(url: &str) -> String {
+    if url.starts_with("//") {
+        format!("https:{url}")
+    } else {
+        url.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_article_extracts_structure_cards_and_images() {
+        let article = ArticleData {
+            id: 1,
+            title: "title".into(),
+            summary: String::new(),
+            content: r#"<h1>标题</h1><p>A &amp; B <a href="https://example.test">链接</a></p><figure><img data-src="//i.test/a.jpg"></figure><figure><img class="video-card" aid="2"></figure>"#.into(),
+            article_type: 0,
+            author: None,
+            publish_time: 0,
+            image_urls: Vec::new(),
+            origin_image_urls: Vec::new(),
+        };
+        let document = article.document();
+        assert!(document.body.contains("# 标题"));
+        assert!(document.body.contains("A & B"));
+        assert!(document.body.contains("https://example.test"));
+        assert!(document.body.contains("[视频 2]"));
+        assert_eq!(document.image_urls, vec!["https://i.test/a.jpg"]);
+        assert!(matches!(document.blocks[0], ArticleBlock::Text(_)));
+        assert!(matches!(document.blocks[1], ArticleBlock::Text(_)));
+        assert!(matches!(
+            &document.blocks[2],
+            ArticleBlock::Image { url, .. } if url == "https://i.test/a.jpg"
+        ));
+        assert!(
+            matches!(
+                &document.blocks[3],
+                ArticleBlock::Embedded(text) if text == "[视频 2]"
+            ),
+            "{:?}",
+            document.blocks
+        );
+    }
+
+    #[test]
+    fn json_article_extracts_text_and_native_images() {
+        let document = document_from_json(
+            r#"{"ops":[{"insert":"hello\n"},{"insert":{"native-image":{"url":"https://i.test/a.jpg"}}},{"insert":{"article-card":{"id":"cv7"}}}]}"#,
+        );
+        assert!(document.body.contains("hello"));
+        assert!(document.body.contains("[图片 1]"));
+        assert!(document.body.contains("[文章 cv7]"));
+        assert_eq!(document.image_urls.len(), 1);
+        assert!(matches!(document.blocks[0], ArticleBlock::Text(_)));
+        assert!(matches!(document.blocks[1], ArticleBlock::Image { .. }));
+        assert!(matches!(document.blocks[2], ArticleBlock::Embedded(_)));
+    }
+
+    #[test]
+    fn json_content_object_deserializes_without_losing_operations() {
+        let article: ArticleData = serde_json::from_value(serde_json::json!({
+            "type": 3,
+            "content": {"ops": [{"insert": "text"}]}
+        }))
+        .unwrap();
+        assert_eq!(article.document().body, "text");
+    }
+}

--- a/src/api/cdn.rs
+++ b/src/api/cdn.rs
@@ -552,13 +552,11 @@ fn speed_score(ratio: f64) -> f64 {
     }
 }
 
-pub async fn rank_streams(data: &PlayUrlData) -> Result<RankedStreams> {
-    let video = data
-        .dash
-        .video
-        .iter()
-        .max_by_key(|stream| (stream.id, stream.bandwidth))
-        .ok_or_else(|| anyhow!("播放地址没有视频流"))?;
+pub async fn rank_streams(
+    data: &PlayUrlData,
+    quality: crate::storage::VideoQuality,
+) -> Result<RankedStreams> {
+    let video = select_video_stream(data, quality)?;
     let mut audio = data.dash.audio.iter().collect::<Vec<_>>();
     if let Some(dolby) = &data.dash.dolby {
         audio.extend(dolby.audio.iter().flatten());
@@ -586,6 +584,18 @@ pub async fn rank_streams(data: &PlayUrlData) -> Result<RankedStreams> {
     })
 }
 
+fn select_video_stream(
+    data: &PlayUrlData,
+    quality: crate::storage::VideoQuality,
+) -> Result<&DashStream> {
+    data.dash
+        .video
+        .iter()
+        .filter(|stream| stream.id <= quality.qn())
+        .max_by_key(|stream| (stream.id, stream.bandwidth))
+        .ok_or_else(|| anyhow!("播放地址没有符合画质上限的视频流"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -606,6 +616,43 @@ mod tests {
             Some(1)
         );
         assert_eq!(data.dash.audio[0].base_url.as_deref(), Some("https://a/a"));
+    }
+
+    #[test]
+    fn video_stream_selection_respects_quality_cap() {
+        let data: PlayUrlData = serde_json::from_value(serde_json::json!({
+            "dash": {
+                "video": [
+                    {"id": 120, "bandwidth": 300},
+                    {"id": 80, "bandwidth": 200},
+                    {"id": 64, "bandwidth": 100}
+                ],
+                "audio": [],
+                "dolby": null,
+                "flac": null
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            select_video_stream(&data, crate::storage::VideoQuality::Best)
+                .unwrap()
+                .id,
+            120
+        );
+        assert_eq!(
+            select_video_stream(&data, crate::storage::VideoQuality::Q1080p)
+                .unwrap()
+                .id,
+            80
+        );
+        assert_eq!(
+            select_video_stream(&data, crate::storage::VideoQuality::Q720p)
+                .unwrap()
+                .id,
+            64
+        );
+        assert!(select_video_stream(&data, crate::storage::VideoQuality::Q360p).is_err());
     }
 
     #[test]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 //! Bilibili API Client with cookie management and WBI signing
 
 use super::wbi;
-use crate::storage::Credentials;
+use crate::storage::{Credentials, VideoQuality};
 use anyhow::{Context, Result, anyhow};
 use reqwest::Client;
 use reqwest::header::{COOKIE, HeaderMap, HeaderValue, REFERER, USER_AGENT};
@@ -524,7 +524,12 @@ impl ApiClient {
             .ok_or_else(|| anyhow::anyhow!("No data in video info response"))
     }
 
-    pub async fn get_play_url(&self, bvid: &str, cid: i64) -> Result<super::cdn::PlayUrlData> {
+    pub async fn get_play_url(
+        &self,
+        bvid: &str,
+        cid: i64,
+        quality: VideoQuality,
+    ) -> Result<super::cdn::PlayUrlData> {
         let url = self.build_url(BilibiliApiDomain::Main, "/x/player/wbi/playurl");
         let resp: ApiResponse<super::cdn::PlayUrlData> = self
             .get_with_wbi(
@@ -532,7 +537,7 @@ impl ApiClient {
                 vec![
                     ("bvid", bvid.to_string()),
                     ("cid", cid.to_string()),
-                    ("qn", "127".to_string()),
+                    ("qn", quality.qn().to_string()),
                     ("fnver", "0".to_string()),
                     ("fnval", "4048".to_string()),
                     ("fourk", "1".to_string()),
@@ -544,6 +549,43 @@ impl ApiClient {
         }
         resp.data
             .ok_or_else(|| anyhow!("playurl response has no data"))
+    }
+
+    pub async fn get_bangumi_play_url(
+        &self,
+        ep_id: i64,
+        quality: VideoQuality,
+    ) -> Result<super::cdn::PlayUrlData> {
+        let url = format!(
+            "{}/pgc/player/web/v2/playurl?ep_id={ep_id}&qn={}&otype=json&fnval=4048&fourk=1&from_client=BROWSER&is_main_page=false&need_fragment=false&isGaiaAvoided=true&web_location=1315873",
+            BilibiliApiDomain::Main.as_str(),
+            quality.qn()
+        );
+        let value = self.get_json(&url).await?;
+        Self::parse_bangumi_play_url(&value)
+    }
+
+    fn parse_bangumi_play_url(value: &serde_json::Value) -> Result<super::cdn::PlayUrlData> {
+        let mut payload = value;
+        if payload.get("code").is_some() {
+            Self::check_code(payload)?;
+        }
+        if let Some(raw) = payload.get("raw") {
+            payload = raw;
+        }
+        if let Some(data) = payload.get("data") {
+            payload = data;
+            if payload.get("code").is_some() {
+                Self::check_code(payload)?;
+            }
+        }
+        if let Some(result) = payload.get("result") {
+            payload = result;
+        }
+        if let Some(video_info) = payload.get("video_info") {
+            payload = video_info;
+        }
+        serde_json::from_value(payload.clone()).context("invalid bangumi playurl response")
     }
 
     pub async fn get_video_danmaku(&self, cid: i64) -> Result<Vec<super::danmaku::VideoDanmaku>> {
@@ -1090,6 +1132,23 @@ impl ApiClient {
             .ok_or_else(|| anyhow::anyhow!("No data in history response"))
     }
 
+    pub async fn delete_history_item(&self, key: &super::history::HistoryKey) -> Result<()> {
+        let url = self.build_url(BilibiliApiDomain::Main, "/x/v2/history/delete");
+        let _: ApiResponse<serde_json::Value> =
+            self.post(&url, vec![("kid", key.api_value())]).await?;
+        Ok(())
+    }
+
+    pub async fn get_article(&self, cvid: i64) -> Result<super::article::ArticleData> {
+        let url = format!(
+            "{}/x/article/view?id={cvid}",
+            BilibiliApiDomain::Main.as_str()
+        );
+        let resp: ApiResponse<super::article::ArticleData> = self.get(&url).await?;
+        resp.data
+            .ok_or_else(|| anyhow!("article response has no data"))
+    }
+
     // ========== Comment Action APIs ==========
 
     /// Add a comment (发表评论)
@@ -1480,6 +1539,27 @@ impl Default for ApiClient {
 mod live_contract_tests {
     use super::ApiClient;
     use crate::api::space::SpaceVideoOrder;
+    use crate::storage::VideoQuality;
+
+    #[test]
+    fn bangumi_v2_playurl_extracts_nested_video_info() {
+        let value = serde_json::json!({
+            "code": 0,
+            "result": {
+                "video_info": {
+                    "dash": {
+                        "video": [{"id": 80, "bandwidth": 10}],
+                        "audio": [{"id": 30280, "bandwidth": 5}],
+                        "dolby": null,
+                        "flac": null
+                    }
+                },
+                "play_view_business_info": {"episode_info": {"cid": 1}}
+            }
+        });
+        let playurl = ApiClient::parse_bangumi_play_url(&value).unwrap();
+        assert_eq!(playurl.dash.video[0].id, 80);
+    }
 
     #[tokio::test]
     #[ignore = "requires a logged-in account and network access"]
@@ -1520,8 +1600,11 @@ mod live_contract_tests {
                 .find_map(|media| media.bvid.as_deref())
             {
                 let info = client.get_video_info(bvid).await.expect("video info");
-                let play_url = client.get_play_url(bvid, info.cid).await.expect("playurl");
-                crate::api::cdn::rank_streams(&play_url)
+                let play_url = client
+                    .get_play_url(bvid, info.cid, VideoQuality::Best)
+                    .await
+                    .expect("playurl");
+                crate::api::cdn::rank_streams(&play_url, VideoQuality::Best)
                     .await
                     .expect("reachable CDN streams");
             }

--- a/src/api/history.rs
+++ b/src/api/history.rs
@@ -5,6 +5,19 @@
 
 use serde::Deserialize;
 
+/// Stable identity used by Bilibili's history deletion endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HistoryKey {
+    pub business: String,
+    pub kid: i64,
+}
+
+impl HistoryKey {
+    pub fn api_value(&self) -> String {
+        format!("{}_{}", self.business, self.kid)
+    }
+}
+
 /// Response data for history cursor API
 #[derive(Debug, Deserialize)]
 pub struct HistoryData {
@@ -38,50 +51,72 @@ pub struct HistoryTab {
 #[derive(Debug, Clone, Deserialize)]
 pub struct HistoryItem {
     /// Title of the content
+    #[serde(default)]
     pub title: String,
     /// Long title (for episodes)
+    #[serde(default)]
     pub long_title: Option<String>,
     /// Cover image URL
+    #[serde(default)]
     pub cover: Option<String>,
     /// Alternative covers
+    #[serde(default)]
     pub covers: Option<Vec<String>>,
     /// URI for navigation
+    #[serde(default)]
     pub uri: Option<String>,
     /// History metadata
     pub history: HistoryMeta,
     /// Number of videos in the content
+    #[serde(default)]
     pub videos: i32,
     /// Author name
+    #[serde(default)]
     pub author_name: String,
     /// Author avatar
+    #[serde(default)]
     pub author_face: Option<String>,
     /// Author mid
+    #[serde(default)]
     pub author_mid: i64,
     /// Last view timestamp
+    #[serde(default)]
     pub view_at: i64,
     /// Watch progress in seconds
+    #[serde(default)]
     pub progress: i64,
     /// Badge text (e.g., "专栏", "直播中", "国创")
+    #[serde(default)]
     pub badge: Option<String>,
     /// Show title for episodes
+    #[serde(default)]
     pub show_title: Option<String>,
     /// Duration in seconds
+    #[serde(default)]
     pub duration: i64,
     /// Current episode info
+    #[serde(default)]
     pub current: Option<String>,
     /// Total episodes
+    #[serde(default)]
     pub total: i32,
     /// New episode description
+    #[serde(default)]
     pub new_desc: Option<String>,
     /// Whether the series is finished
+    #[serde(default)]
     pub is_finish: i32,
     /// Whether favorited
+    #[serde(default)]
     pub is_fav: i32,
     /// Kid for certain types
+    #[serde(default)]
     pub kid: i64,
     /// Tag name
+    #[serde(default)]
     pub tag_name: Option<String>,
     /// Live status (0: not live, 1: live)
+    #[serde(default)]
     pub live_status: i32,
 }
 
@@ -89,20 +124,28 @@ pub struct HistoryItem {
 #[derive(Debug, Clone, Deserialize)]
 pub struct HistoryMeta {
     /// Object ID
+    #[serde(default)]
     pub oid: i64,
     /// Episode ID (for pgc)
+    #[serde(default)]
     pub epid: i64,
     /// BV ID (for archive)
+    #[serde(default)]
     pub bvid: Option<String>,
     /// Page number
+    #[serde(default)]
     pub page: i32,
     /// CID
+    #[serde(default)]
     pub cid: i64,
     /// Part name
+    #[serde(default)]
     pub part: Option<String>,
     /// Business type: archive, pgc, live, article, article-list
+    #[serde(default)]
     pub business: String,
     /// Device type
+    #[serde(default)]
     pub dt: i32,
 }
 
@@ -190,6 +233,29 @@ impl HistoryItem {
         self.history.business == "live"
     }
 
+    pub fn is_article(&self) -> bool {
+        matches!(self.history.business.as_str(), "article" | "article-list")
+    }
+
+    pub fn is_selectable(&self) -> bool {
+        self.is_video() || self.is_article()
+    }
+
+    pub fn history_key(&self) -> Option<HistoryKey> {
+        (self.kid > 0 && self.is_selectable()).then(|| HistoryKey {
+            business: self.history.business.clone(),
+            kid: self.kid,
+        })
+    }
+
+    pub fn article_id(&self) -> Option<i64> {
+        match self.history.business.as_str() {
+            "article" => (self.history.oid > 0).then_some(self.history.oid),
+            "article-list" => (self.history.cid > 0).then_some(self.history.cid),
+            _ => None,
+        }
+    }
+
     /// Get bvid if available
     pub fn get_bvid(&self) -> Option<&str> {
         self.history.bvid.as_deref().filter(|s| !s.is_empty())
@@ -233,5 +299,49 @@ impl HistoryItem {
             .find(|seg| !seg.is_empty())?;
 
         first_segment.parse::<i64>().ok().filter(|id| *id > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mixed_history_records_deserialize_and_route_ids() {
+        let items: Vec<HistoryItem> = serde_json::from_value(serde_json::json!([
+            {
+                "title": "video",
+                "kid": 11,
+                "history": {"oid": 11, "bvid": "BV1test", "business": "archive"}
+            },
+            {
+                "title": "vip episode",
+                "kid": 22,
+                "history": {"epid": 2201, "bvid": "", "business": "pgc"}
+            },
+            {
+                "title": "article",
+                "kid": 33,
+                "covers": ["https://i.test/article.jpg"],
+                "history": {"oid": 3301, "business": "article"}
+            },
+            {
+                "title": "article list",
+                "kid": 44,
+                "history": {"oid": 4400, "cid": 4401, "business": "article-list"}
+            }
+        ]))
+        .expect("mixed history fixture");
+
+        assert_eq!(items[0].get_bvid(), Some("BV1test"));
+        assert_eq!(items[1].get_bvid(), None);
+        assert_eq!(items[1].history.epid, 2201);
+        assert_eq!(items[2].get_cover(), Some("https://i.test/article.jpg"));
+        assert_eq!(items[2].article_id(), Some(3301));
+        assert_eq!(items[3].article_id(), Some(4401));
+        assert_eq!(
+            items[3].history_key().unwrap().api_value(),
+            "article-list_44"
+        );
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod article;
 pub mod auth;
 pub mod bangumi;
 pub mod cdn;

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -623,6 +623,9 @@ impl App {
             AppAction::DeleteHistoryItems(keys) => {
                 if self.credentials.is_none() {
                     self.apply_login_required_hint();
+                    if let Page::History(page) = &mut self.current_page {
+                        page.cancel_deletion();
+                    }
                     return;
                 }
                 if keys.is_empty() {

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -2,9 +2,9 @@ use crate::app::{App, PreviousPage};
 use crate::application::{AppAction, network};
 use crate::infrastructure::{media, persistence};
 use crate::presentation::tui::{
-    BangumiDetailPage, BangumiPage, DynamicDetailPage, DynamicPage, FavoritesPage, HistoryPage,
-    HomePage, LiveDetailPage, LivePage, LoginPage, NavItem, Page, SearchPage, SettingsPage, Theme,
-    UpPage,
+    ArticleDetailPage, BangumiDetailPage, BangumiPage, DynamicDetailPage, DynamicPage,
+    FavoritesPage, HistoryPage, HomePage, LiveDetailPage, LivePage, LoginPage, NavItem, Page,
+    SearchPage, SettingsPage, Theme, UpPage,
 };
 use std::sync::Arc;
 
@@ -117,6 +117,7 @@ impl App {
                     None,
                     self.credentials.as_ref(),
                     self.config.danmaku.clone(),
+                    self.config.video_quality,
                     self.playback_event_tx.clone(),
                     session_id,
                 )
@@ -153,6 +154,7 @@ impl App {
                         Some(page.page),
                         self.credentials.as_ref(),
                         self.config.danmaku.clone(),
+                        self.config.video_quality,
                         self.playback_event_tx.clone(),
                         session_id,
                     )
@@ -618,6 +620,37 @@ impl App {
                     });
                 }
             }
+            AppAction::DeleteHistoryItems(keys) => {
+                if self.credentials.is_none() {
+                    self.apply_login_required_hint();
+                    return;
+                }
+                if keys.is_empty() {
+                    return;
+                }
+                let req_id = self.next_request_id("history_delete");
+                self.send_network_command(network::NetworkCommand::DeleteHistory { req_id, keys });
+            }
+            AppAction::OpenArticle(cvid) => {
+                let page = ArticleDetailPage::new(cvid);
+                let previous =
+                    std::mem::replace(&mut self.current_page, Page::ArticleDetail(Box::new(page)));
+                self.navigation_stack.push(previous);
+                let req_id = self.next_request_id("article_detail");
+                self.send_network_command(network::NetworkCommand::LoadArticle { req_id, cvid });
+            }
+            AppAction::OpenHistoryBangumi { season_id, ep_id } => {
+                let page =
+                    BangumiDetailPage::new_for_episode(season_id, ep_id, self.config.auto_play);
+                let previous =
+                    std::mem::replace(&mut self.current_page, Page::BangumiDetail(Box::new(page)));
+                self.navigation_stack.push(previous);
+                let req_id = self.next_request_id("bangumi_detail");
+                self.send_network_command(network::NetworkCommand::LoadBangumiDetail {
+                    req_id,
+                    season_id,
+                });
+            }
             AppAction::SwitchToHistory => {
                 self.sidebar.select(NavItem::History);
                 self.current_page = Page::History(HistoryPage::new());
@@ -696,6 +729,7 @@ impl App {
                     self.credentials.is_some(),
                     self.config.danmaku.clone(),
                     self.config.auto_play,
+                    self.config.video_quality,
                 );
                 self.current_page = Page::Settings(Box::new(page));
             }
@@ -780,6 +814,10 @@ impl App {
             }
             AppAction::SaveAutoPlay(enabled) => {
                 self.config.auto_play = enabled;
+                let _ = persistence::save_config(&self.config);
+            }
+            AppAction::SaveVideoQuality(quality) => {
+                self.config.video_quality = quality;
                 let _ = persistence::save_config(&self.config);
             }
             AppAction::SwitchToLive => {
@@ -921,7 +959,25 @@ impl App {
                 season_id: _,
                 title: _,
             } => {
-                let _ = media::play_bangumi_episode(ep_id, self.credentials.as_ref()).await;
+                let session_id = self.allocate_playback_session();
+                self.playback.session_id = None;
+                self.playback.status = crate::domain::playback::PlaybackStatus::Starting;
+                match media::play_bangumi_episode(
+                    self.api_client.clone(),
+                    ep_id,
+                    self.credentials.as_ref(),
+                    self.config.video_quality,
+                    self.playback_event_tx.clone(),
+                    session_id,
+                )
+                .await
+                {
+                    Ok(()) => self.playback.begin_session(session_id),
+                    Err(error) => {
+                        self.playback.status = crate::domain::playback::PlaybackStatus::Failed;
+                        self.playback.last_error = Some(format!("启动番剧播放器失败: {error:#}"));
+                    }
+                }
             }
             AppAction::None => {}
         }
@@ -944,6 +1000,7 @@ impl App {
             order,
             start_index,
             self.credentials.as_ref(),
+            self.config.video_quality,
             self.playback_event_tx.clone(),
             session_id,
         )
@@ -1016,6 +1073,7 @@ impl App {
                         false,
                         self.config.danmaku.clone(),
                         self.config.auto_play,
+                        self.config.video_quality,
                     )));
                 }
             }
@@ -1027,6 +1085,7 @@ impl App {
                         self.credentials.is_some(),
                         self.config.danmaku.clone(),
                         self.config.auto_play,
+                        self.config.video_quality,
                     );
                     self.current_page = Page::Settings(Box::new(page));
                 }
@@ -1108,6 +1167,9 @@ impl App {
             }
             Page::DynamicDetail(_) => {
                 // DynamicDetail is initialized when created
+            }
+            Page::ArticleDetail(_) => {
+                // ArticleDetail is initialized when opened from history.
             }
             Page::History(page) => {
                 if self.credentials.is_none() {

--- a/src/app/network_events.rs
+++ b/src/app/network_events.rs
@@ -137,6 +137,33 @@ impl App {
                     }
                 }
             }
+            network::NetworkEvent::HistoryDeleted {
+                req_id,
+                successful,
+                failed,
+            } => {
+                if !self.is_latest_request("history_delete", req_id) {
+                    return;
+                }
+                if let Page::History(page) = &mut self.current_page {
+                    page.apply_delete_result(successful, failed);
+                }
+            }
+            network::NetworkEvent::ArticleLoaded {
+                req_id,
+                cvid,
+                article,
+                comments,
+            } => {
+                if !self.is_latest_request("article_detail", req_id) {
+                    return;
+                }
+                if let Page::ArticleDetail(page) = &mut self.current_page
+                    && page.cvid == cvid
+                {
+                    page.set_article(article, comments);
+                }
+            }
             network::NetworkEvent::LiveLoaded {
                 req_id,
                 append,
@@ -444,6 +471,9 @@ impl App {
                     (Page::DynamicDetail(page), "dynamic_detail") => {
                         page.error_message = Some(format!("加载动态详情失败: {}", error));
                         page.loading = false;
+                    }
+                    (Page::ArticleDetail(page), "article_detail") => {
+                        page.set_error(format!("加载专栏失败: {error}"));
                     }
                     (Page::Bangumi(page), "bangumi_timeline") => {
                         page.set_error(format!("加载番剧时间表失败: {}", error));

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -72,6 +72,7 @@ impl App {
             Page::Login(_)
                 | Page::VideoDetail(_)
                 | Page::DynamicDetail(_)
+                | Page::ArticleDetail(_)
                 | Page::BangumiDetail(_)
                 | Page::Up(_)
         ) {
@@ -101,6 +102,7 @@ impl App {
             Page::Login(_)
                 | Page::VideoDetail(_)
                 | Page::DynamicDetail(_)
+                | Page::ArticleDetail(_)
                 | Page::BangumiDetail(_)
                 | Page::Up(_)
         ) {
@@ -108,6 +110,7 @@ impl App {
                 Page::Login(page) => page.draw(frame, area, &self.theme, &self.keybindings),
                 Page::VideoDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
                 Page::DynamicDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
+                Page::ArticleDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
                 Page::BangumiDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
                 Page::Up(page) => page.draw(frame, area, &self.theme, &self.keybindings),
                 _ => {}
@@ -169,6 +172,7 @@ impl App {
             Page::Search(page) => page.draw(frame, area, &self.theme, &self.keybindings),
             Page::Dynamic(page) => page.draw(frame, area, &self.theme, &self.keybindings),
             Page::DynamicDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
+            Page::ArticleDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
             Page::VideoDetail(page) => page.draw(frame, area, &self.theme, &self.keybindings),
             Page::History(page) => page.draw(frame, area, &self.theme, &self.keybindings),
             Page::Favorites(page) => page.draw(frame, area, &self.theme, &self.keybindings),
@@ -192,8 +196,9 @@ impl App {
             Page::Search(page) => page.handle_input(key, keys),
             Page::Dynamic(page) => page.handle_input_with_modifiers(key, modifiers, keys),
             Page::DynamicDetail(page) => page.handle_input(key, keys),
+            Page::ArticleDetail(page) => page.handle_input(key, keys),
             Page::VideoDetail(page) => page.handle_input(key, keys),
-            Page::History(page) => page.handle_input(key, keys),
+            Page::History(page) => page.handle_input_with_modifiers(key, modifiers, keys),
             Page::Favorites(page) => page.handle_input(key, keys),
             Page::Live(page) => page.handle_input(key, keys),
             Page::LiveDetail(page) => page.handle_input(key, keys),
@@ -215,6 +220,7 @@ impl App {
             Page::Search(page) => page.handle_mouse(event, area),
             Page::Dynamic(page) => page.handle_mouse(event, area),
             Page::DynamicDetail(page) => page.handle_mouse(event, area),
+            Page::ArticleDetail(page) => page.handle_mouse(event, area),
             Page::VideoDetail(page) => page.handle_mouse(event, area),
             Page::History(page) => page.handle_mouse(event, area),
             Page::Favorites(page) => page.handle_mouse(event, area),
@@ -273,15 +279,20 @@ impl App {
         }
 
         let auto_play = if self.config.auto_play {
-            if let Page::VideoDetail(page) = &mut self.current_page {
-                if page.auto_play_pending && !page.loading && page.video_info.is_some() {
+            match &mut self.current_page {
+                Page::VideoDetail(page)
+                    if page.auto_play_pending && !page.loading && page.video_info.is_some() =>
+                {
                     page.auto_play_pending = false;
-                    Some((page.bvid.clone(), page.play_action()))
-                } else {
-                    None
+                    Some((Some(page.bvid.clone()), page.play_action()))
                 }
-            } else {
-                None
+                Page::BangumiDetail(page)
+                    if page.auto_play_pending && !page.loading && page.season.is_some() =>
+                {
+                    page.auto_play_pending = false;
+                    page.play_action().map(|action| (None, action))
+                }
+                _ => None,
             }
         } else {
             // Auto-play disabled: clear the pending flag so it doesn't fire
@@ -289,11 +300,14 @@ impl App {
             if let Page::VideoDetail(page) = &mut self.current_page {
                 page.auto_play_pending = false;
             }
+            if let Page::BangumiDetail(page) = &mut self.current_page {
+                page.auto_play_pending = false;
+            }
             None
         };
-        if let Some((bvid, action)) = auto_play {
+        if let Some((return_bvid, action)) = auto_play {
             self.handle_action(action).await;
-            if let Some(session_id) = self.playback.session_id {
+            if let (Some(bvid), Some(session_id)) = (return_bvid, self.playback.session_id) {
                 self.auto_return_after_playback = Some((session_id, bvid));
             }
         }
@@ -320,6 +334,10 @@ impl App {
             Page::VideoDetail(page) => {
                 page.poll_cover_results();
                 page.start_cover_downloads();
+            }
+            Page::ArticleDetail(page) => {
+                page.poll_image_results();
+                page.start_image_downloads();
             }
             Page::History(page) => {
                 page.poll_cover_results();

--- a/src/application/action.rs
+++ b/src/application/action.rs
@@ -1,9 +1,10 @@
 use crate::api::favorite::{FavoriteOrder, FavoriteSource};
+use crate::api::history::HistoryKey;
 use crate::api::recommend::HomeFeed;
 use crate::api::space::SpaceVideoOrder;
 use crate::api::video::VideoPage;
 use crate::domain::playback::{PlayOrder, PlaylistItem, PlaylistSource};
-use crate::infrastructure::persistence::{Credentials, DanmakuConfig, Keybindings};
+use crate::infrastructure::persistence::{Credentials, DanmakuConfig, Keybindings, VideoQuality};
 use crate::presentation::tui::DynamicTab;
 
 /// Actions that can be triggered from UI components
@@ -89,6 +90,12 @@ pub enum AppAction {
     LoadMoreDynamic,
     /// Load more history items
     LoadMoreHistory,
+    DeleteHistoryItems(Vec<HistoryKey>),
+    OpenArticle(i64),
+    OpenHistoryBangumi {
+        season_id: i64,
+        ep_id: i64,
+    },
     /// Load more comments in video detail page
     LoadMoreComments,
     /// Toggle comment replies expansion
@@ -107,6 +114,7 @@ pub enum AppAction {
     SaveDanmakuConfig(Box<DanmakuConfig>),
     /// Save the auto-play-on-video-open preference.
     SaveAutoPlay(bool),
+    SaveVideoQuality(VideoQuality),
     /// Logout and return to login page
     Logout,
     /// Like or unlike a comment (oid, rpid, comment_type)

--- a/src/application/network.rs
+++ b/src/application/network.rs
@@ -1,15 +1,15 @@
 use crate::api::{
     ApiClient,
+    article::ArticleData,
     bangumi::{SeasonRankItem, SeasonResult},
-    comment::CommentItem,
+    comment::{CommentItem, CommentType},
     dynamic::DynamicItem,
     dynamic::UpListItem,
     favorite::{
         CollectedFolder, FavoriteFolder, FavoriteOrder, FavoriteResourceData, FavoriteSource,
         SeasonArchivesData, WatchLaterData,
     },
-    history::HistoryCursor,
-    history::HistoryData,
+    history::{HistoryCursor, HistoryData, HistoryKey},
     live::LiveRoom,
     recommend::{HomeFeed, VideoItem},
     search::HotwordItem,
@@ -68,6 +68,14 @@ pub enum NetworkCommand {
     LoadHistoryMore {
         req_id: u64,
         cursor: HistoryCursor,
+    },
+    DeleteHistory {
+        req_id: u64,
+        keys: Vec<HistoryKey>,
+    },
+    LoadArticle {
+        req_id: u64,
+        cvid: i64,
     },
     LoadLiveInit {
         req_id: u64,
@@ -170,6 +178,17 @@ pub enum NetworkEvent {
         req_id: u64,
         append: bool,
         data: HistoryData,
+    },
+    HistoryDeleted {
+        req_id: u64,
+        successful: Vec<HistoryKey>,
+        failed: Vec<(HistoryKey, String)>,
+    },
+    ArticleLoaded {
+        req_id: u64,
+        cvid: i64,
+        article: ArticleData,
+        comments: Vec<CommentItem>,
     },
     LiveLoaded {
         req_id: u64,
@@ -332,6 +351,8 @@ impl NetworkCommand {
             | Self::LoadDynamicRefresh { .. }
             | Self::LoadDynamicMore { .. } => "dynamic",
             Self::LoadHistoryInit { .. } | Self::LoadHistoryMore { .. } => "history",
+            Self::DeleteHistory { .. } => "history_delete",
+            Self::LoadArticle { .. } => "article_detail",
             Self::LoadLiveInit { .. } | Self::LoadLiveMore { .. } => "live",
             Self::LoadVideoDetail { .. } => "video_detail",
             Self::LoadUpPage { .. } | Self::LoadUpVideos { .. } => "up",
@@ -706,6 +727,50 @@ async fn handle_command(api_client: Arc<ApiClient>, command: NetworkCommand) -> 
                 data,
             },
             Err(e) => failed(req_id, "history_more", e),
+        },
+        NetworkCommand::DeleteHistory { req_id, keys } => {
+            let mut successful = Vec::new();
+            let mut failed_keys = Vec::new();
+            for key in keys {
+                match api_client.delete_history_item(&key).await {
+                    Ok(()) => successful.push(key),
+                    Err(error) => failed_keys.push((key, error.to_string())),
+                }
+            }
+            NetworkEvent::HistoryDeleted {
+                req_id,
+                successful,
+                failed: failed_keys,
+            }
+        }
+        NetworkCommand::LoadArticle { req_id, cvid } => match api_client.get_article(cvid).await {
+            Ok(article) => {
+                let comment_oid = if article.id > 0 { article.id } else { cvid };
+                let comments = api_client
+                    .get_dynamic_comments(comment_oid, CommentType::Article.as_i32(), 1)
+                    .await
+                    .ok()
+                    .map(|data| {
+                        let mut comments = data.hots.unwrap_or_default();
+                        for comment in data.replies.unwrap_or_default() {
+                            if !comments
+                                .iter()
+                                .any(|existing| existing.rpid == comment.rpid)
+                            {
+                                comments.push(comment);
+                            }
+                        }
+                        comments
+                    })
+                    .unwrap_or_default();
+                NetworkEvent::ArticleLoaded {
+                    req_id,
+                    cvid,
+                    article,
+                    comments,
+                }
+            }
+            Err(error) => failed(req_id, "article_detail", error),
         },
         NetworkCommand::LoadLiveInit { req_id } => {
             let rooms = match api_client.get_live_home_rooms().await {

--- a/src/infrastructure/persistence.rs
+++ b/src/infrastructure/persistence.rs
@@ -1,4 +1,4 @@
 pub use crate::storage::{
-    AppConfig, Credentials, DanmakuConfig, Keybindings, delete_credentials, load_config,
-    load_credentials, save_config, save_credentials,
+    AppConfig, Credentials, DanmakuConfig, Keybindings, VideoQuality, delete_credentials,
+    load_config, load_credentials, save_config, save_credentials,
 };

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -3,7 +3,7 @@ use crate::api::danmaku::VideoDanmaku;
 use crate::api::live_danmaku_hub::LiveDanmakuHub;
 use crate::api::live_ws::LiveMessage;
 use crate::domain::playback::{PlayOrder, PlaybackEvent, PlaylistItem};
-use crate::storage::{Credentials, DanmakuConfig};
+use crate::storage::{Credentials, DanmakuConfig, VideoQuality};
 use anyhow::Result;
 use std::collections::VecDeque;
 use std::io::Write as StdWrite;
@@ -28,6 +28,13 @@ static LIVE_SESSION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static MPV_IPC_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 const LIVE_DANMAKU_SCRIPT: &str = include_str!("live_danmaku.lua");
 
+fn ytdl_format(quality: VideoQuality) -> String {
+    match quality.max_height() {
+        None => "bestvideo+bestaudio/best".to_string(),
+        Some(height) => format!("bestvideo[height<={height}]+bestaudio/best[height<={height}]"),
+    }
+}
+
 /// Play a video using mpv with yt-dlp and report watch progress
 /// This function spawns mpv in a background task to avoid blocking the TUI
 #[allow(clippy::too_many_arguments)]
@@ -40,6 +47,7 @@ pub async fn play_video(
     page_num: Option<i32>,
     credentials: Option<&Credentials>,
     danmaku_config: DanmakuConfig,
+    video_quality: VideoQuality,
     playback_event_tx: Sender<PlaybackEvent>,
     session_id: u64,
 ) -> Result<()> {
@@ -53,8 +61,8 @@ pub async fn play_video(
 
     let start_ts = chrono::Utc::now().timestamp();
 
-    let mut media_proxy = match api_client.get_play_url(bvid, cid).await {
-        Ok(play_url) => match crate::api::cdn::rank_streams(&play_url).await {
+    let mut media_proxy = match api_client.get_play_url(bvid, cid, video_quality).await {
+        Ok(play_url) => match crate::api::cdn::rank_streams(&play_url, video_quality).await {
             Ok(streams) => proxy::MediaProxy::start(streams).await.ok(),
             Err(_) => None,
         },
@@ -99,7 +107,7 @@ pub async fn play_video(
         cmd.arg(format!("--audio-file={}", proxy.audio_url));
         cmd.arg(&proxy.video_url);
     } else {
-        cmd.arg("--ytdl-format=bestvideo+bestaudio/best");
+        cmd.arg(format!("--ytdl-format={}", ytdl_format(video_quality)));
         cmd.arg(&webpage_url);
     }
 
@@ -626,17 +634,20 @@ async fn switch_to_working_video_cdn(
 
 /// Start one mpv process with multiple Bilibili URLs. mpv owns automatic
 /// advancement, so window/fullscreen/volume state is preserved between items.
+#[allow(clippy::too_many_arguments)]
 pub async fn play_playlist(
     api_client: Arc<ApiClient>,
     items: Vec<PlaylistItem>,
     order: PlayOrder,
     start_index: usize,
     _credentials: Option<&Credentials>,
+    video_quality: VideoQuality,
     playback_event_tx: Sender<PlaybackEvent>,
     session_id: u64,
 ) -> Result<()> {
     let (items, requested_start) = ordered_playlist(items, order, start_index)?;
-    let (first, skipped) = prepare_next_playlist_item(&api_client, &items, requested_start).await;
+    let (first, skipped) =
+        prepare_next_playlist_item(&api_client, &items, requested_start, video_quality).await;
     let Some((start_index, first)) = first else {
         anyhow::bail!("播放列表没有可播放项目: {}", skipped.join("; "));
     };
@@ -672,6 +683,7 @@ pub async fn play_playlist(
             items,
             start_index,
             first,
+            video_quality,
             playback_event_tx.clone(),
             session_id,
         )
@@ -705,6 +717,7 @@ struct PreparedPlaylistItem {
 async fn prepare_playlist_item(
     api_client: &ApiClient,
     item: &PlaylistItem,
+    video_quality: VideoQuality,
 ) -> Result<PreparedPlaylistItem> {
     let (cid, duration) = match (item.cid, item.duration) {
         (Some(cid), Some(duration)) => (cid, duration),
@@ -716,8 +729,10 @@ async fn prepare_playlist_item(
             )
         }
     };
-    let play_url = api_client.get_play_url(&item.bvid, cid).await?;
-    let streams = crate::api::cdn::rank_streams(&play_url).await?;
+    let play_url = api_client
+        .get_play_url(&item.bvid, cid, video_quality)
+        .await?;
+    let streams = crate::api::cdn::rank_streams(&play_url, video_quality).await?;
     let proxy = proxy::MediaProxy::start(streams).await?;
     Ok(PreparedPlaylistItem {
         cid,
@@ -730,12 +745,13 @@ async fn prepare_next_playlist_item(
     api_client: &ApiClient,
     items: &[PlaylistItem],
     start: usize,
+    video_quality: VideoQuality,
 ) -> (Option<(usize, PreparedPlaylistItem)>, Vec<String>) {
     let mut failures = Vec::new();
     for (index, item) in items.iter().enumerate().skip(start) {
         if let Some(prepared) = accept_prepared_result(
             item,
-            prepare_playlist_item(api_client, item).await,
+            prepare_playlist_item(api_client, item, video_quality).await,
             &mut failures,
         ) {
             return (Some((index, prepared)), failures);
@@ -800,6 +816,7 @@ async fn run_playlist(
     items: Vec<PlaylistItem>,
     mut index: usize,
     mut prepared: PreparedPlaylistItem,
+    video_quality: VideoQuality,
     tx: Sender<PlaybackEvent>,
     session_id: u64,
 ) -> Result<()> {
@@ -893,7 +910,12 @@ async fn run_playlist(
                     played_any = true;
                     if !corrupted { prepared.proxy.record_success(); }
                 }
-                let (next, skipped) = prepare_next_playlist_item(&api_client, &items, index + 1).await;
+                let (next, skipped) = prepare_next_playlist_item(
+                    &api_client,
+                    &items,
+                    index + 1,
+                    video_quality,
+                ).await;
                 log_skipped_playlist_items(&skipped);
                 let Some((next_index, next_prepared)) = next else {
                     let _ = mpv_ipc(ipc_path, serde_json::json!(["quit"])).await;
@@ -1067,10 +1089,24 @@ fn ordered_playlist(
     Ok((items, start_index))
 }
 
-/// Play a bangumi episode using mpv with yt-dlp
-/// This function spawns mpv in a background task to avoid blocking the TUI
-pub async fn play_bangumi_episode(ep_id: i64, credentials: Option<&Credentials>) -> Result<()> {
+/// Play an authenticated bangumi episode, falling back to yt-dlp when the
+/// direct PGC stream cannot be proxied.
+pub async fn play_bangumi_episode(
+    api_client: Arc<ApiClient>,
+    ep_id: i64,
+    credentials: Option<&Credentials>,
+    video_quality: VideoQuality,
+    playback_event_tx: Sender<PlaybackEvent>,
+    session_id: u64,
+) -> Result<()> {
     let video_url = format!("https://www.bilibili.com/bangumi/play/ep{}", ep_id);
+    let media_proxy = match api_client.get_bangumi_play_url(ep_id, video_quality).await {
+        Ok(play_url) => match crate::api::cdn::rank_streams(&play_url, video_quality).await {
+            Ok(streams) => proxy::MediaProxy::start(streams).await.ok(),
+            Err(_) => None,
+        },
+        Err(_) => None,
+    };
 
     let mut cmd = Command::new("mpv");
     cmd.stdout(Stdio::null());
@@ -1087,10 +1123,18 @@ pub async fn play_bangumi_episode(ep_id: i64, credentials: Option<&Credentials>)
         None
     };
 
-    cmd.arg("--ytdl-format=bestvideo+bestaudio/best");
     cmd.arg("--force-window=immediate");
     cmd.arg("--script-opts-append=double_video_fps=yes");
-    cmd.arg(&video_url);
+    cmd.arg(format!("--referrer={video_url}"));
+    cmd.arg(format!("--http-header-fields=Referer: {video_url}"));
+    if let Some(proxy) = &media_proxy {
+        cmd.arg("--ytdl=no");
+        cmd.arg(format!("--audio-file={}", proxy.audio_url));
+        cmd.arg(&proxy.video_url);
+    } else {
+        cmd.arg(format!("--ytdl-format={}", ytdl_format(video_quality)));
+        cmd.arg(&video_url);
+    }
 
     let mut child = match cmd.spawn() {
         Ok(child) => child,
@@ -1103,12 +1147,28 @@ pub async fn play_bangumi_episode(ep_id: i64, credentials: Option<&Credentials>)
     };
 
     tokio::spawn(async move {
-        let _ = child.wait().await;
+        let status = child.wait().await;
 
         // Cleanup cookie file
         if let Some(path) = cookie_path_to_clean {
             let _ = crate::storage::remove_cookie_export(&path);
         }
+        drop(media_proxy);
+        let event = match status {
+            Ok(status) if status.success() => PlaybackEvent::Finished {
+                session_id,
+                bvid: None,
+            },
+            Ok(status) => PlaybackEvent::Failed {
+                session_id,
+                error: format!("番剧播放器退出: {status}"),
+            },
+            Err(error) => PlaybackEvent::Failed {
+                session_id,
+                error: format!("番剧播放器失败: {error}"),
+            },
+        };
+        let _ = playback_event_tx.send(event);
     });
 
     Ok(())
@@ -1679,8 +1739,11 @@ mod playlist_tests {
         let client = ApiClient::new();
         let bvid = "BV1cP7j64E37";
         let info = client.get_video_info(bvid).await.expect("video info");
-        let play_url = client.get_play_url(bvid, info.cid).await.expect("playurl");
-        let streams = crate::api::cdn::rank_streams(&play_url)
+        let play_url = client
+            .get_play_url(bvid, info.cid, VideoQuality::Best)
+            .await
+            .expect("playurl");
+        let streams = crate::api::cdn::rank_streams(&play_url, VideoQuality::Best)
             .await
             .expect("rank CDN streams");
         assert!(streams.video.len() > 1, "test needs a backup video CDN");

--- a/src/presentation/tui/mod.rs
+++ b/src/presentation/tui/mod.rs
@@ -1,6 +1,6 @@
 pub use crate::ui::{
-    BangumiDetailPage, BangumiPage, Component, DEFAULT_THEME_ID, DynamicDetailPage, DynamicPage,
-    DynamicTab, FavoritesPage, HistoryPage, HomePage, LiveDetailPage, LivePage, LoginPage, NavItem,
-    Page, SearchPage, SettingsPage, Sidebar, Theme, ThemeChoice, UpPage, VideoCard, VideoCardGrid,
-    VideoDetailPage,
+    ArticleDetailPage, BangumiDetailPage, BangumiPage, Component, DEFAULT_THEME_ID,
+    DynamicDetailPage, DynamicPage, DynamicTab, FavoritesPage, HistoryPage, HomePage,
+    LiveDetailPage, LivePage, LoginPage, NavItem, Page, SearchPage, SettingsPage, Sidebar, Theme,
+    ThemeChoice, UpPage, VideoCard, VideoCardGrid, VideoDetailPage,
 };

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -474,6 +474,8 @@ pub struct AppConfig {
     pub danmaku: DanmakuConfig,
     #[serde(default = "default_true")]
     pub auto_play: bool,
+    #[serde(default)]
+    pub video_quality: VideoQuality,
 }
 
 impl Default for AppConfig {
@@ -483,6 +485,79 @@ impl Default for AppConfig {
             keybindings: Keybindings::default(),
             danmaku: DanmakuConfig::default(),
             auto_play: true,
+            video_quality: VideoQuality::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum VideoQuality {
+    #[default]
+    Best,
+    Q4k,
+    Q1080pHigh,
+    Q1080p,
+    Q720p,
+    Q480p,
+    Q360p,
+}
+
+impl VideoQuality {
+    pub const ALL: [Self; 7] = [
+        Self::Best,
+        Self::Q4k,
+        Self::Q1080pHigh,
+        Self::Q1080p,
+        Self::Q720p,
+        Self::Q480p,
+        Self::Q360p,
+    ];
+
+    pub const fn qn(self) -> i64 {
+        match self {
+            Self::Best => 127,
+            Self::Q4k => 120,
+            Self::Q1080pHigh => 116,
+            Self::Q1080p => 80,
+            Self::Q720p => 64,
+            Self::Q480p => 32,
+            Self::Q360p => 16,
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Best => "最佳",
+            Self::Q4k => "4K",
+            Self::Q1080pHigh => "1080P+/60",
+            Self::Q1080p => "1080P",
+            Self::Q720p => "720P",
+            Self::Q480p => "480P",
+            Self::Q360p => "360P",
+        }
+    }
+
+    pub fn cycle(self, direction: i32) -> Self {
+        let index = Self::ALL
+            .iter()
+            .position(|quality| *quality == self)
+            .unwrap_or(0);
+        if direction >= 0 {
+            Self::ALL[(index + 1) % Self::ALL.len()]
+        } else {
+            Self::ALL[(index + Self::ALL.len() - 1) % Self::ALL.len()]
+        }
+    }
+
+    pub const fn max_height(self) -> Option<u16> {
+        match self {
+            Self::Best => None,
+            Self::Q4k => Some(2160),
+            Self::Q1080pHigh | Self::Q1080p => Some(1080),
+            Self::Q720p => Some(720),
+            Self::Q480p => Some(480),
+            Self::Q360p => Some(360),
         }
     }
 }
@@ -606,6 +681,19 @@ mod config_tests {
         });
         let config: AppConfig = serde_json::from_value(value).expect("legacy config");
         assert_eq!(config.danmaku, DanmakuConfig::default());
+        assert_eq!(config.video_quality, VideoQuality::Best);
+    }
+
+    #[test]
+    fn video_quality_has_stable_qn_mapping_and_round_trips() {
+        assert_eq!(VideoQuality::Q4k.qn(), 120);
+        assert_eq!(VideoQuality::Q1080pHigh.qn(), 116);
+        let value = serde_json::to_value(VideoQuality::Q720p).unwrap();
+        assert_eq!(value, "q720p");
+        assert_eq!(
+            serde_json::from_value::<VideoQuality>(value).unwrap(),
+            VideoQuality::Q720p
+        );
     }
 
     #[test]

--- a/src/ui/article_detail.rs
+++ b/src/ui/article_detail.rs
@@ -1,0 +1,412 @@
+//! Full-page article reader used by history entries.
+
+use super::{Component, Theme};
+use crate::api::{
+    article::{ArticleBlock, ArticleData},
+    comment::CommentItem,
+};
+use crate::application::AppAction;
+use crate::storage::Keybindings;
+use image::DynamicImage;
+use ratatui::{
+    crossterm::event::{KeyCode, MouseEvent, MouseEventKind},
+    prelude::*,
+    widgets::*,
+};
+use ratatui_image::{StatefulImage, picker::Picker, protocol::StatefulProtocol};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+struct ImageResult {
+    index: usize,
+    protocol: Option<StatefulProtocol>,
+}
+
+pub struct ArticleDetailPage {
+    pub cvid: i64,
+    pub article: Option<ArticleData>,
+    pub loading: bool,
+    pub error_message: Option<String>,
+    blocks: Vec<ArticleBlock>,
+    comments: Vec<CommentItem>,
+    image_urls: Vec<String>,
+    image_protocols: Vec<Option<StatefulProtocol>>,
+    scroll: u16,
+    visible_height: u16,
+    picker: Arc<Picker>,
+    image_tx: mpsc::Sender<ImageResult>,
+    image_rx: mpsc::Receiver<ImageResult>,
+    pending_downloads: HashSet<usize>,
+    failed_images: HashSet<usize>,
+}
+
+impl ArticleDetailPage {
+    pub fn new(cvid: i64) -> Self {
+        let picker = Arc::new(Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks()));
+        let (image_tx, image_rx) = mpsc::channel(8);
+        Self {
+            cvid,
+            article: None,
+            loading: true,
+            error_message: None,
+            blocks: Vec::new(),
+            comments: Vec::new(),
+            image_urls: Vec::new(),
+            image_protocols: Vec::new(),
+            scroll: 0,
+            visible_height: 1,
+            picker,
+            image_tx,
+            image_rx,
+            pending_downloads: HashSet::new(),
+            failed_images: HashSet::new(),
+        }
+    }
+
+    pub fn set_article(&mut self, article: ArticleData, comments: Vec<CommentItem>) {
+        let document = article.document();
+        self.blocks = document.blocks;
+        self.comments = comments;
+        self.image_urls = document.image_urls;
+        self.image_protocols = (0..self.image_urls.len()).map(|_| None).collect();
+        self.article = Some(article);
+        self.loading = false;
+        self.error_message = None;
+        self.scroll = 0;
+        self.pending_downloads.clear();
+        self.failed_images.clear();
+    }
+
+    pub fn set_error(&mut self, message: String) {
+        self.loading = false;
+        self.error_message = Some(message);
+    }
+
+    pub fn start_image_downloads(&mut self) {
+        if self.pending_downloads.len() >= 4 {
+            return;
+        }
+        let Some(index) = (0..self.image_urls.len()).find(|index| {
+            self.image_protocols[*index].is_none()
+                && !self.pending_downloads.contains(index)
+                && !self.failed_images.contains(index)
+        }) else {
+            return;
+        };
+        let url = self.image_urls[index].clone();
+        self.pending_downloads.insert(index);
+        let tx = self.image_tx.clone();
+        let picker = Arc::clone(&self.picker);
+        tokio::spawn(async move {
+            let protocol = download_image(&url)
+                .await
+                .map(|image| picker.new_resize_protocol(image));
+            let _ = tx.send(ImageResult { index, protocol }).await;
+        });
+    }
+
+    pub fn poll_image_results(&mut self) {
+        while let Ok(result) = self.image_rx.try_recv() {
+            self.pending_downloads.remove(&result.index);
+            if let Some(protocol) = result.protocol {
+                if let Some(slot) = self.image_protocols.get_mut(result.index) {
+                    *slot = Some(protocol);
+                }
+            } else {
+                self.failed_images.insert(result.index);
+            }
+        }
+    }
+
+    fn render_document(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.border_subtle))
+            .title(" 正文 ");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        self.visible_height = inner.height.max(1);
+
+        let blocks = self.blocks.clone();
+        let heights = blocks
+            .iter()
+            .map(|block| article_block_height(block, inner.width))
+            .collect::<Vec<_>>();
+        let total_height = heights.iter().copied().sum::<u16>().max(1);
+        self.scroll = self
+            .scroll
+            .min(total_height.saturating_sub(self.visible_height));
+
+        let viewport_start = self.scroll;
+        let viewport_end = viewport_start.saturating_add(self.visible_height);
+        let mut document_y = 0u16;
+        for (article_block, block_height) in blocks.iter().zip(heights) {
+            let block_end = document_y.saturating_add(block_height);
+            if block_end <= viewport_start {
+                document_y = block_end;
+                continue;
+            }
+            if document_y >= viewport_end {
+                break;
+            }
+            let visible_start = document_y.max(viewport_start);
+            let visible_end = block_end.min(viewport_end);
+            let render_area = Rect::new(
+                inner.x,
+                inner.y + visible_start.saturating_sub(viewport_start),
+                inner.width,
+                visible_end.saturating_sub(visible_start),
+            );
+            if render_area.is_empty() {
+                document_y = block_end;
+                continue;
+            }
+            let clipped_rows = visible_start.saturating_sub(document_y);
+            match article_block {
+                ArticleBlock::Text(text) => {
+                    frame.render_widget(
+                        Paragraph::new(text.as_str())
+                            .wrap(Wrap { trim: false })
+                            .scroll((clipped_rows, 0))
+                            .style(Style::default().fg(theme.fg_primary)),
+                        render_area,
+                    );
+                }
+                ArticleBlock::Embedded(text) => {
+                    frame.render_widget(
+                        Paragraph::new(text.as_str())
+                            .alignment(Alignment::Center)
+                            .style(
+                                Style::default()
+                                    .fg(theme.fg_accent)
+                                    .add_modifier(Modifier::BOLD),
+                            ),
+                        render_area,
+                    );
+                }
+                ArticleBlock::Image { url, alt } => {
+                    self.render_inline_image(frame, render_area, url, alt, theme);
+                }
+            }
+            document_y = block_end;
+        }
+    }
+
+    fn render_inline_image(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        url: &str,
+        alt: &str,
+        theme: &Theme,
+    ) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.border_subtle))
+            .title(format!(" {alt} "));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let Some(index) = self
+            .image_urls
+            .iter()
+            .position(|candidate| candidate == url)
+        else {
+            return;
+        };
+        if let Some(Some(protocol)) = self.image_protocols.get_mut(index) {
+            frame.render_stateful_widget(StatefulImage::default(), inner, protocol);
+        } else {
+            let message = if self.failed_images.contains(&index) {
+                "图片加载失败"
+            } else {
+                "图片加载中..."
+            };
+            frame.render_widget(Paragraph::new(message).alignment(Alignment::Center), inner);
+        }
+    }
+
+    fn render_comments(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.border_subtle))
+            .title(format!(" 评论 {} ", self.comments.len()));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if self.comments.is_empty() {
+            frame.render_widget(
+                Paragraph::new("暂无评论")
+                    .alignment(Alignment::Center)
+                    .style(Style::default().fg(theme.fg_muted)),
+                inner,
+            );
+            return;
+        }
+
+        let mut lines = Vec::new();
+        for comment in &self.comments {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    comment.author_name(),
+                    Style::default()
+                        .fg(theme.fg_accent)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {}  👍{}", comment.format_time(), comment.format_like()),
+                    Style::default().fg(theme.fg_muted),
+                ),
+            ]));
+            lines.push(Line::styled(
+                comment.message().to_string(),
+                Style::default().fg(theme.fg_primary),
+            ));
+            lines.push(Line::default());
+        }
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+    }
+}
+
+impl Component for ArticleDetailPage {
+    fn draw(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, keys: &Keybindings) {
+        let chunks = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        let title = self
+            .article
+            .as_ref()
+            .map(|article| article.title.as_str())
+            .unwrap_or("加载专栏...");
+        let metadata = self
+            .article
+            .as_ref()
+            .map(|article| {
+                let author = article
+                    .author
+                    .as_ref()
+                    .map(|author| author.name.as_str())
+                    .unwrap_or("");
+                let published = chrono::DateTime::from_timestamp(article.publish_time, 0)
+                    .map(|date| {
+                        date.with_timezone(&chrono::Local)
+                            .format("%Y-%m-%d %H:%M")
+                            .to_string()
+                    })
+                    .unwrap_or_default();
+                match (author.is_empty(), published.is_empty()) {
+                    (false, false) => format!("{author} · {published}"),
+                    (false, true) => author.to_string(),
+                    (true, false) => published,
+                    (true, true) => String::new(),
+                }
+            })
+            .unwrap_or_default();
+        frame.render_widget(
+            Paragraph::new(format!("{title}\n{metadata}"))
+                .alignment(Alignment::Center)
+                .style(
+                    Style::default()
+                        .fg(theme.fg_primary)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .block(Block::default().borders(Borders::BOTTOM)),
+            chunks[0],
+        );
+
+        if self.loading {
+            frame.render_widget(
+                Paragraph::new("加载中...").alignment(Alignment::Center),
+                chunks[1],
+            );
+        } else if let Some(error) = &self.error_message {
+            frame.render_widget(
+                Paragraph::new(error.as_str())
+                    .alignment(Alignment::Center)
+                    .style(Style::default().fg(theme.error)),
+                chunks[1],
+            );
+        } else {
+            let content =
+                Layout::horizontal([Constraint::Percentage(68), Constraint::Percentage(32)])
+                    .split(chunks[1]);
+            self.render_document(frame, content[0], theme);
+            self.render_comments(frame, content[1], theme);
+        }
+
+        let muted = Style::default().fg(theme.fg_secondary);
+        let accent = Style::default()
+            .fg(theme.fg_accent)
+            .add_modifier(Modifier::BOLD);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(" [", muted),
+                Span::styled(keys.get_arrow_keys_display(), accent),
+                Span::styled("/", muted),
+                Span::styled(keys.get_nav_keys_display(), accent),
+                Span::styled("] 滚动  [", muted),
+                Span::styled(format!("{}/{}", keys.page_up, keys.page_down), accent),
+                Span::styled("] 翻页  [", muted),
+                Span::styled(
+                    &keys.back,
+                    Style::default().fg(theme.info).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("] 返回", muted),
+            ]))
+            .alignment(Alignment::Center),
+            chunks[2],
+        );
+    }
+
+    fn handle_input(&mut self, key: KeyCode, keys: &Keybindings) -> Option<AppAction> {
+        if keys.matches_back(key) || key == KeyCode::Esc {
+            return Some(AppAction::BackToList);
+        }
+        if keys.matches_up(key) {
+            self.scroll = self.scroll.saturating_sub(1);
+        } else if keys.matches_down(key) {
+            self.scroll = self.scroll.saturating_add(1);
+        } else if keys.matches_page_up(key) {
+            self.scroll = self.scroll.saturating_sub(self.visible_height);
+        } else if keys.matches_page_down(key) {
+            self.scroll = self.scroll.saturating_add(self.visible_height);
+        } else if keys.matches_quit(key) {
+            return Some(AppAction::Quit);
+        }
+        None
+    }
+
+    fn handle_mouse(&mut self, event: MouseEvent, _area: Rect) -> Option<AppAction> {
+        match event.kind {
+            MouseEventKind::ScrollUp => self.scroll = self.scroll.saturating_sub(1),
+            MouseEventKind::ScrollDown => self.scroll = self.scroll.saturating_add(1),
+            _ => {}
+        }
+        None
+    }
+}
+
+async fn download_image(url: &str) -> Option<DynamicImage> {
+    let response = reqwest::get(url).await.ok()?;
+    let bytes = response.bytes().await.ok()?;
+    image::load_from_memory(&bytes).ok()
+}
+
+fn article_block_height(block: &ArticleBlock, width: u16) -> u16 {
+    match block {
+        ArticleBlock::Text(text) => {
+            let width = width.max(1) as usize;
+            text.lines()
+                .map(|line| Line::from(line).width().max(1).div_ceil(width) as u16)
+                .sum::<u16>()
+                .saturating_add(1)
+        }
+        ArticleBlock::Image { .. } => 14,
+        ArticleBlock::Embedded(_) => 2,
+    }
+}

--- a/src/ui/article_detail.rs
+++ b/src/ui/article_detail.rs
@@ -1,6 +1,6 @@
 //! Full-page article reader used by history entries.
 
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::{
     article::{ArticleBlock, ArticleData},
     comment::CommentItem,
@@ -21,6 +21,12 @@ use tokio::sync::mpsc;
 struct ImageResult {
     index: usize,
     protocol: Option<StatefulProtocol>,
+}
+
+struct ArticleImageState<'a> {
+    urls: &'a [String],
+    protocols: &'a mut [Option<StatefulProtocol>],
+    failed: &'a HashSet<usize>,
 }
 
 pub struct ArticleDetailPage {
@@ -129,8 +135,8 @@ impl ArticleDetailPage {
         frame.render_widget(block, area);
         self.visible_height = inner.height.max(1);
 
-        let blocks = self.blocks.clone();
-        let heights = blocks
+        let heights = self
+            .blocks
             .iter()
             .map(|block| article_block_height(block, inner.width))
             .collect::<Vec<_>>();
@@ -142,7 +148,7 @@ impl ArticleDetailPage {
         let viewport_start = self.scroll;
         let viewport_end = viewport_start.saturating_add(self.visible_height);
         let mut document_y = 0u16;
-        for (article_block, block_height) in blocks.iter().zip(heights) {
+        for (article_block, block_height) in self.blocks.iter().zip(heights) {
             let block_end = document_y.saturating_add(block_height);
             if block_end <= viewport_start {
                 document_y = block_end;
@@ -187,7 +193,12 @@ impl ArticleDetailPage {
                     );
                 }
                 ArticleBlock::Image { url, alt } => {
-                    self.render_inline_image(frame, render_area, url, alt, theme);
+                    let mut images = ArticleImageState {
+                        urls: &self.image_urls,
+                        protocols: &mut self.image_protocols,
+                        failed: &self.failed_images,
+                    };
+                    Self::render_inline_image(frame, render_area, url, alt, theme, &mut images);
                 }
             }
             document_y = block_end;
@@ -195,12 +206,12 @@ impl ArticleDetailPage {
     }
 
     fn render_inline_image(
-        &mut self,
         frame: &mut Frame,
         area: Rect,
         url: &str,
         alt: &str,
         theme: &Theme,
+        images: &mut ArticleImageState<'_>,
     ) {
         let block = Block::default()
             .borders(Borders::ALL)
@@ -209,17 +220,13 @@ impl ArticleDetailPage {
             .title(format!(" {alt} "));
         let inner = block.inner(area);
         frame.render_widget(block, area);
-        let Some(index) = self
-            .image_urls
-            .iter()
-            .position(|candidate| candidate == url)
-        else {
+        let Some(index) = images.urls.iter().position(|candidate| candidate == url) else {
             return;
         };
-        if let Some(Some(protocol)) = self.image_protocols.get_mut(index) {
+        if let Some(Some(protocol)) = images.protocols.get_mut(index) {
             frame.render_stateful_widget(StatefulImage::default(), inner, protocol);
         } else {
-            let message = if self.failed_images.contains(&index) {
+            let message = if images.failed.contains(&index) {
                 "图片加载失败"
             } else {
                 "图片加载中..."
@@ -339,25 +346,27 @@ impl Component for ArticleDetailPage {
             self.render_comments(frame, content[1], theme);
         }
 
-        let muted = Style::default().fg(theme.fg_secondary);
-        let accent = Style::default()
-            .fg(theme.fg_accent)
-            .add_modifier(Modifier::BOLD);
         frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(" [", muted),
-                Span::styled(keys.get_arrow_keys_display(), accent),
-                Span::styled("/", muted),
-                Span::styled(keys.get_nav_keys_display(), accent),
-                Span::styled("] 滚动  [", muted),
-                Span::styled(format!("{}/{}", keys.page_up, keys.page_down), accent),
-                Span::styled("] 翻页  [", muted),
-                Span::styled(
-                    &keys.back,
-                    Style::default().fg(theme.info).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("] 返回", muted),
-            ]))
+            Paragraph::new(shortcut_footer(
+                theme,
+                [
+                    (
+                        format!(
+                            "{}/{}",
+                            keys.get_arrow_keys_display(),
+                            keys.get_nav_keys_display()
+                        ),
+                        "滚动".into(),
+                        theme.fg_accent,
+                    ),
+                    (
+                        format!("{}/{}", keys.page_up, keys.page_down),
+                        "翻页".into(),
+                        theme.fg_accent,
+                    ),
+                    (keys.back.clone(), "返回".into(), theme.info),
+                ],
+            ))
             .alignment(Alignment::Center),
             chunks[2],
         );

--- a/src/ui/bangumi_detail.rs
+++ b/src/ui/bangumi_detail.rs
@@ -1,6 +1,6 @@
 //! Bangumi detail page showing season info and episode list
 
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::bangumi::{BangumiEpisode, SeasonResult};
 use crate::api::client::ApiClient;
 use crate::application::AppAction;
@@ -19,6 +19,8 @@ pub struct BangumiDetailPage {
     pub error_message: Option<String>,
     pub episode_scroll: usize,
     pub selected_episode: usize,
+    target_episode_id: Option<i64>,
+    pub auto_play_pending: bool,
     // Flat list of all episodes for navigation
     flat_episodes: Vec<FlatEpisode>,
     last_click_time: Option<Instant>,
@@ -41,10 +43,19 @@ impl BangumiDetailPage {
             error_message: None,
             episode_scroll: 0,
             selected_episode: 0,
+            target_episode_id: None,
+            auto_play_pending: false,
             flat_episodes: Vec::new(),
             last_click_time: None,
             last_click_index: None,
         }
+    }
+
+    pub fn new_for_episode(season_id: i64, ep_id: i64, auto_play: bool) -> Self {
+        let mut page = Self::new(season_id);
+        page.target_episode_id = Some(ep_id);
+        page.auto_play_pending = auto_play;
+        page
     }
 
     pub fn set_season(&mut self, season: SeasonResult) {
@@ -61,8 +72,18 @@ impl BangumiDetailPage {
         self.season = Some(season);
         self.loading = false;
         self.error_message = None;
-        self.selected_episode = 0;
+        let target_index = self.target_episode_id.and_then(|ep_id| {
+            self.flat_episodes
+                .iter()
+                .position(|episode| episode.episode.id == ep_id)
+        });
+        self.selected_episode = target_index.unwrap_or(0);
+        if self.target_episode_id.is_some() && target_index.is_none() {
+            self.auto_play_pending = false;
+            self.error_message = Some("未找到历史记录对应的番剧剧集".to_string());
+        }
         self.episode_scroll = 0;
+        self.update_scroll();
     }
 
     pub fn set_error(&mut self, msg: String) {
@@ -87,6 +108,10 @@ impl BangumiDetailPage {
                 season_id: self.season_id,
                 title: fe.episode.display_title(),
             })
+    }
+
+    pub fn play_action(&self) -> Option<AppAction> {
+        self.selected_action()
     }
 
     fn move_down(&mut self) {
@@ -322,13 +347,19 @@ impl Component for BangumiDetailPage {
         self.render_episodes(frame, chunks[1], theme);
 
         // Help
-        let help_text = format!(
-            "[{}/{}] 滚动 [{}] 播放 [{}] 返回",
-            keys.nav_up, keys.nav_down, keys.confirm, keys.back
-        );
-        let help = Paragraph::new(help_text)
-            .style(Style::default().fg(theme.fg_secondary))
-            .alignment(Alignment::Center);
+        let help = Paragraph::new(shortcut_footer(
+            theme,
+            [
+                (
+                    format!("{}/{}", keys.nav_up, keys.nav_down),
+                    "滚动".into(),
+                    theme.fg_accent,
+                ),
+                (keys.confirm.clone(), "播放".into(), theme.success),
+                (keys.back.clone(), "返回".into(), theme.info),
+            ],
+        ))
+        .alignment(Alignment::Center);
         frame.render_widget(help, chunks[2]);
     }
 
@@ -422,5 +453,42 @@ impl Component for BangumiDetailPage {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_episode_is_preselected_for_auto_play() {
+        let season: SeasonResult = serde_json::from_value(serde_json::json!({
+            "title": "season",
+            "season_id": 7,
+            "cover": "",
+            "square_cover": "",
+            "evaluate": null,
+            "link": null,
+            "episodes": [
+                {"aid": 1, "cid": 11, "id": 101, "title": "1"},
+                {"aid": 2, "cid": 22, "id": 202, "title": "2"}
+            ],
+            "section": null,
+            "rating": null,
+            "stat": null,
+            "badge": null,
+            "is_finish": null,
+            "index_show": null
+        }))
+        .unwrap();
+        let mut page = BangumiDetailPage::new_for_episode(7, 202, true);
+        page.set_season(season);
+
+        assert_eq!(page.selected_episode, 1);
+        assert!(page.auto_play_pending);
+        assert!(matches!(
+            page.play_action(),
+            Some(AppAction::PlayBangumiEpisode { ep_id: 202, .. })
+        ));
     }
 }

--- a/src/ui/dynamic.rs
+++ b/src/ui/dynamic.rs
@@ -1,7 +1,7 @@
 //! Dynamic feed page with video card grid display
 
 use super::video_card::{VideoCard, VideoCardGrid};
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::dynamic::DynamicItem;
 use crate::application::AppAction;
@@ -484,11 +484,21 @@ impl Component for DynamicPage {
         }
 
         frame.render_widget(
-            Paragraph::new(format!(
-                "[↑/↓] 选择动态  [{}/{}] 翻页  [←/→] 切换面板  [{}] 切标签  [{}] 详情  [{}] 刷新",
-                keys.page_up, keys.page_down, keys.tab_1, keys.confirm, keys.refresh
+            Paragraph::new(shortcut_footer(
+                theme,
+                [
+                    ("↑/↓".into(), "选择动态".into(), theme.fg_accent),
+                    (
+                        format!("{}/{}", keys.page_up, keys.page_down),
+                        "翻页".into(),
+                        theme.fg_accent,
+                    ),
+                    ("←/→".into(), "切换面板".into(), theme.fg_accent),
+                    (keys.tab_1.clone(), "切标签".into(), theme.info),
+                    (keys.confirm.clone(), "详情".into(), theme.success),
+                    (keys.refresh.clone(), "刷新".into(), theme.info),
+                ],
             ))
-            .style(Style::default().fg(theme.fg_secondary))
             .alignment(Alignment::Center),
             chunks[2],
         );

--- a/src/ui/dynamic_detail.rs
+++ b/src/ui/dynamic_detail.rs
@@ -1,6 +1,6 @@
 //! Dynamic detail page for viewing image/text dynamics
 
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::comment::CommentItem;
 use crate::api::dynamic::DynamicItem;
@@ -418,28 +418,51 @@ impl Component for DynamicDetailPage {
         } else {
             chunks[2]
         };
-        let help_text = if self.input_mode {
-            format!("[{}] 发送评论  [{}] 取消", keys.confirm, keys.back)
+        let help = if self.input_mode {
+            shortcut_footer(
+                theme,
+                [
+                    (keys.confirm.clone(), "发送评论".into(), theme.success),
+                    (keys.back.clone(), "取消".into(), theme.info),
+                ],
+            )
         } else if !self.image_urls.is_empty() {
-            format!(
-                "[{}/{}] 图片  [{}/{}] 滚动  [{}] 点赞  [{}] 评论  [n] 加载更多  [{}] 返回",
-                keys.nav_left,
-                keys.nav_right,
-                keys.nav_up,
-                keys.nav_down,
-                keys.confirm,
-                keys.comment,
-                keys.back
+            shortcut_footer(
+                theme,
+                [
+                    (
+                        format!("{}/{}", keys.nav_left, keys.nav_right),
+                        "图片".into(),
+                        theme.fg_accent,
+                    ),
+                    (
+                        format!("{}/{}", keys.nav_up, keys.nav_down),
+                        "滚动".into(),
+                        theme.fg_accent,
+                    ),
+                    (keys.confirm.clone(), "点赞".into(), theme.success),
+                    (keys.comment.clone(), "评论".into(), theme.info),
+                    ("n".into(), "加载更多".into(), theme.info),
+                    (keys.back.clone(), "返回".into(), theme.info),
+                ],
             )
         } else {
-            format!(
-                "[{}/{}] 滚动  [{}] 点赞  [{}] 评论  [n] 加载更多  [{}] 返回",
-                keys.nav_up, keys.nav_down, keys.confirm, keys.comment, keys.back
+            shortcut_footer(
+                theme,
+                [
+                    (
+                        format!("{}/{}", keys.nav_up, keys.nav_down),
+                        "滚动".into(),
+                        theme.fg_accent,
+                    ),
+                    (keys.confirm.clone(), "点赞".into(), theme.success),
+                    (keys.comment.clone(), "评论".into(), theme.info),
+                    ("n".into(), "加载更多".into(), theme.info),
+                    (keys.back.clone(), "返回".into(), theme.info),
+                ],
             )
         };
-        let help = Paragraph::new(help_text)
-            .style(Style::default().fg(theme.fg_secondary))
-            .alignment(Alignment::Center);
+        let help = Paragraph::new(help).alignment(Alignment::Center);
         frame.render_widget(help, help_chunk);
     }
 

--- a/src/ui/favorites.rs
+++ b/src/ui/favorites.rs
@@ -1,4 +1,4 @@
-use super::{Component, Theme, VideoCard, VideoCardGrid};
+use super::{Component, Theme, VideoCard, VideoCardGrid, shortcut_footer};
 use crate::api::favorite::{
     CollectedFolder, FavoriteFolder, FavoriteResourceData, FavoriteSource, SeasonArchivesData,
     WatchLaterData,
@@ -8,7 +8,7 @@ use crate::storage::Keybindings;
 use ratatui::{
     Frame,
     crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind},
-    layout::{Constraint, Direction, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Position, Rect},
     style::{Modifier, Style},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
@@ -317,13 +317,22 @@ impl Component for FavoritesPage {
             self.videos.render(frame, right[1], theme);
         }
         frame.render_widget(
-            Paragraph::new(format!(
-                "[↑/↓] 选择  [{}/{}] 翻页  [←/→] 收藏/视频  [Enter] 打开  [{}] 下一页面  [{}] 上一页面",
-                keys.page_up,
-                keys.page_down,
-                keys.nav_next_page,
-                keys.nav_prev_page
-            )),
+            Paragraph::new(shortcut_footer(
+                theme,
+                [
+                    ("↑/↓".into(), "选择".into(), theme.fg_accent),
+                    (
+                        format!("{}/{}", keys.page_up, keys.page_down),
+                        "翻页".into(),
+                        theme.fg_accent,
+                    ),
+                    ("←/→".into(), "收藏/视频".into(), theme.fg_accent),
+                    (keys.confirm.clone(), "打开".into(), theme.success),
+                    (keys.nav_next_page.clone(), "下一页面".into(), theme.info),
+                    (keys.nav_prev_page.clone(), "上一页面".into(), theme.info),
+                ],
+            ))
+            .alignment(Alignment::Center),
             right[2],
         );
         let _ = sources;

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -175,6 +175,16 @@ impl HistoryPage {
         self.loading = false;
     }
 
+    /// Leave the in-flight deletion state when the request cannot be started,
+    /// such as when credentials expire between confirmation and dispatch.
+    pub fn cancel_deletion(&mut self) {
+        self.mode = if self.selected_keys.is_empty() {
+            HistoryMode::Browse
+        } else {
+            HistoryMode::Selecting
+        };
+    }
+
     pub async fn load_more(&mut self, api_client: &ApiClient) {
         if self.loading || !self.has_more {
             return;
@@ -1045,5 +1055,20 @@ mod tests {
         page.handle_input_with_modifiers(KeyCode::Esc, KeyModifiers::NONE, &keys);
         assert!(page.selected_keys.is_empty());
         assert_eq!(page.mode, HistoryMode::Browse);
+    }
+
+    #[test]
+    fn cancel_deletion_restores_selection_mode() {
+        let mut page = history_page();
+        page.selected_keys.insert(HistoryKey {
+            business: "archive".into(),
+            kid: 1,
+        });
+        page.mode = HistoryMode::Deleting;
+
+        page.cancel_deletion();
+
+        assert_eq!(page.mode, HistoryMode::Selecting);
+        assert_eq!(page.selected_keys.len(), 1);
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -2,12 +2,12 @@
 
 use super::{Component, Theme};
 use crate::api::client::ApiClient;
-use crate::api::history::{HistoryCursor, HistoryItem};
+use crate::api::history::{HistoryCursor, HistoryItem, HistoryKey};
 use crate::application::AppAction;
 use crate::storage::Keybindings;
 use image::DynamicImage;
 use ratatui::{
-    crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind},
+    crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind},
     prelude::*,
     widgets::*,
 };
@@ -26,7 +26,16 @@ struct HistoryCard {
 /// Message for completed cover download
 struct CoverResult {
     index: usize,
+    generation: u64,
     protocol: StatefulProtocol,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HistoryMode {
+    Browse,
+    Selecting,
+    ConfirmDelete,
+    Deleting,
 }
 
 pub struct HistoryPage {
@@ -43,6 +52,10 @@ pub struct HistoryPage {
     cover_rx: mpsc::Receiver<CoverResult>,
     cover_tx: mpsc::Sender<CoverResult>,
     cached_visible_rows: usize,
+    selected_keys: HashSet<HistoryKey>,
+    mode: HistoryMode,
+    notice: Option<String>,
+    generation: u64,
 
     last_click_time: Option<Instant>,
     last_click_index: Option<usize>,
@@ -71,6 +84,10 @@ impl HistoryPage {
             cover_rx: rx,
             cover_tx: tx,
             cached_visible_rows: Self::INITIAL_VISIBLE_ROWS,
+            selected_keys: HashSet::new(),
+            mode: HistoryMode::Browse,
+            notice: None,
+            generation: 0,
             last_click_time: None,
             last_click_index: None,
         }
@@ -93,6 +110,7 @@ impl HistoryPage {
                 self.cursor = Some(data.cursor);
                 self.has_more = !self.items.is_empty();
                 self.loading = false;
+                self.reset_selection_and_downloads();
             }
             Err(e) => {
                 self.error = Some(format!("加载历史记录失败: {}", e));
@@ -121,6 +139,7 @@ impl HistoryPage {
         self.scroll_offset = 0;
         self.loading = false;
         self.error = None;
+        self.reset_selection_and_downloads();
     }
 
     pub fn start_load_more_request(&mut self) -> Option<crate::api::history::HistoryCursor> {
@@ -233,6 +252,7 @@ impl HistoryPage {
             let url = cover_url.to_string();
             let tx = self.cover_tx.clone();
             let picker = Arc::clone(&self.picker);
+            let generation = self.generation;
 
             tokio::spawn(async move {
                 if let Some(img) = Self::download_image(&url).await {
@@ -240,6 +260,7 @@ impl HistoryPage {
                     let _ = tx
                         .send(CoverResult {
                             index: idx,
+                            generation,
                             protocol,
                         })
                         .await;
@@ -251,6 +272,9 @@ impl HistoryPage {
     /// Poll for completed cover downloads (non-blocking)
     pub fn poll_cover_results(&mut self) {
         while let Ok(result) = self.cover_rx.try_recv() {
+            if result.generation != self.generation {
+                continue;
+            }
             self.pending_downloads.remove(&result.index);
             if result.index < self.items.len() {
                 self.items[result.index].cover_protocol = Some(result.protocol);
@@ -303,7 +327,7 @@ impl HistoryPage {
     }
 
     fn action_for_history_item(item: &HistoryItem) -> Option<AppAction> {
-        if item.is_video() {
+        if item.history.business == "archive" {
             if let Some(bvid) = item.get_bvid() {
                 let aid = item.history.oid;
                 return Some(AppAction::OpenVideoDetail(bvid.to_string(), aid));
@@ -311,11 +335,123 @@ impl HistoryPage {
             return None;
         }
 
+        if item.history.business == "pgc" {
+            return (item.kid > 0 && item.history.epid > 0).then_some(
+                AppAction::OpenHistoryBangumi {
+                    season_id: item.kid,
+                    ep_id: item.history.epid,
+                },
+            );
+        }
+
+        if let Some(cvid) = item.article_id() {
+            return Some(AppAction::OpenArticle(cvid));
+        }
+
         if item.is_live() && item.live_status == 1 {
             return item.get_live_room_id().map(AppAction::OpenLiveDetail);
         }
 
         None
+    }
+
+    fn reset_selection_and_downloads(&mut self) {
+        self.selected_keys.clear();
+        self.mode = HistoryMode::Browse;
+        self.notice = None;
+        self.pending_downloads.clear();
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    fn toggle_selected(&mut self) {
+        let Some(key) = self
+            .items
+            .get(self.selected)
+            .and_then(|card| card.item.history_key())
+        else {
+            self.notice = Some("直播记录不支持批量选择".to_string());
+            return;
+        };
+        let newly_selected = if self.selected_keys.remove(&key) {
+            false
+        } else {
+            self.selected_keys.insert(key);
+            true
+        };
+        self.mode = if self.selected_keys.is_empty() {
+            HistoryMode::Browse
+        } else {
+            HistoryMode::Selecting
+        };
+        self.notice = None;
+        if newly_selected && self.selected + 1 < self.items.len() {
+            self.selected += 1;
+            self.update_scroll(self.cached_visible_rows.max(1));
+        }
+    }
+
+    fn select_all_loaded(&mut self) {
+        self.selected_keys = self
+            .items
+            .iter()
+            .filter_map(|card| card.item.history_key())
+            .collect();
+        self.mode = if self.selected_keys.is_empty() {
+            HistoryMode::Browse
+        } else {
+            HistoryMode::Selecting
+        };
+        self.notice = None;
+    }
+
+    fn invert_loaded_selection(&mut self) {
+        let eligible: HashSet<_> = self
+            .items
+            .iter()
+            .filter_map(|card| card.item.history_key())
+            .collect();
+        self.selected_keys = eligible.difference(&self.selected_keys).cloned().collect();
+        self.mode = if self.selected_keys.is_empty() {
+            HistoryMode::Browse
+        } else {
+            HistoryMode::Selecting
+        };
+        self.notice = None;
+    }
+
+    pub fn apply_delete_result(
+        &mut self,
+        successful: Vec<HistoryKey>,
+        failed: Vec<(HistoryKey, String)>,
+    ) {
+        let successful: HashSet<_> = successful.into_iter().collect();
+        let success_count = successful.len();
+        self.items.retain(|card| {
+            card.item
+                .history_key()
+                .is_none_or(|key| !successful.contains(&key))
+        });
+        self.pending_downloads.clear();
+        self.generation = self.generation.wrapping_add(1);
+        for card in &mut self.items {
+            card.cover_protocol = None;
+        }
+
+        self.selected_keys = failed.iter().map(|(key, _)| key.clone()).collect();
+        let failed_count = failed.len();
+        self.mode = if failed_count == 0 {
+            HistoryMode::Browse
+        } else {
+            HistoryMode::Selecting
+        };
+        self.selected = self.selected.min(self.items.len().saturating_sub(1));
+        let total_rows = self.items.len().div_ceil(Self::COLUMNS);
+        self.scroll_offset = self.scroll_offset.min(total_rows.saturating_sub(1));
+        self.notice = Some(if failed_count == 0 {
+            format!("已删除 {success_count} 条历史记录")
+        } else {
+            format!("已删除 {success_count} 条，{failed_count} 条失败并保留选择")
+        });
     }
 }
 
@@ -326,7 +462,7 @@ impl Default for HistoryPage {
 }
 
 impl Component for HistoryPage {
-    fn draw(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, _keys: &Keybindings) {
+    fn draw(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, keys: &Keybindings) {
         // Main block
         let block = Block::default()
             .borders(Borders::ALL)
@@ -370,8 +506,12 @@ impl Component for HistoryPage {
             return;
         }
 
-        // Render grid
-        self.render_grid(frame, inner, theme);
+        let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+        self.render_grid(frame, chunks[0], theme);
+        self.render_footer(frame, chunks[1], theme, keys);
+        if self.mode == HistoryMode::ConfirmDelete {
+            self.render_delete_confirmation(frame, area, theme);
+        }
     }
 
     fn handle_input(
@@ -379,11 +519,75 @@ impl Component for HistoryPage {
         key: KeyCode,
         keys: &crate::storage::Keybindings,
     ) -> Option<AppAction> {
+        self.handle_input_with_modifiers(key, KeyModifiers::NONE, keys)
+    }
+
+    fn handle_input_with_modifiers(
+        &mut self,
+        key: KeyCode,
+        modifiers: KeyModifiers,
+        keys: &crate::storage::Keybindings,
+    ) -> Option<AppAction> {
+        if self.mode == HistoryMode::Deleting {
+            return None;
+        }
+        if self.mode == HistoryMode::ConfirmDelete {
+            if key == KeyCode::Esc || keys.matches_back(key) {
+                self.mode = HistoryMode::Selecting;
+                return None;
+            }
+            if keys.matches_confirm(key) {
+                self.mode = HistoryMode::Deleting;
+                return Some(AppAction::DeleteHistoryItems(
+                    self.selected_keys.iter().cloned().collect(),
+                ));
+            }
+            return None;
+        }
+
+        if modifiers.contains(KeyModifiers::CONTROL) && key == KeyCode::Char('a') {
+            self.select_all_loaded();
+            return None;
+        }
+        if modifiers.contains(KeyModifiers::CONTROL) && key == KeyCode::Char('r') {
+            self.invert_loaded_selection();
+            return None;
+        }
+        if key == KeyCode::Char(' ') {
+            self.toggle_selected();
+            return None;
+        }
+        if key == KeyCode::Char('d') {
+            if self.selected_keys.is_empty() {
+                let Some(key) = self
+                    .items
+                    .get(self.selected)
+                    .and_then(|card| card.item.history_key())
+                else {
+                    self.notice = Some("该记录不支持删除".to_string());
+                    return None;
+                };
+                self.selected_keys.insert(key);
+            }
+            self.notice = None;
+            self.mode = HistoryMode::ConfirmDelete;
+            return None;
+        }
+        if key == KeyCode::Esc || keys.matches_back(key) {
+            if !self.selected_keys.is_empty() {
+                self.selected_keys.clear();
+                self.mode = HistoryMode::Browse;
+                self.notice = None;
+                return None;
+            }
+            return Some(AppAction::BackToList);
+        }
+
         let cols = Self::COLUMNS;
         let total = self.items.len();
 
-        if keys.matches_quit(key) || keys.matches_back(key) {
-            return Some(AppAction::BackToList);
+        if keys.matches_quit(key) {
+            return Some(AppAction::Quit);
         }
         if keys.matches_left(key) {
             if self.selected > 0 {
@@ -430,6 +634,9 @@ impl Component for HistoryPage {
             return Some(AppAction::OpenUpPage(item.item.author_mid));
         }
         if keys.matches_confirm(key) {
+            if !self.selected_keys.is_empty() {
+                return None;
+            }
             if let Some(card) = self.items.get(self.selected) {
                 return Self::action_for_history_item(&card.item);
             }
@@ -448,6 +655,12 @@ impl Component for HistoryPage {
     }
 
     fn handle_mouse(&mut self, event: MouseEvent, area: Rect) -> Option<AppAction> {
+        if matches!(
+            self.mode,
+            HistoryMode::ConfirmDelete | HistoryMode::Deleting
+        ) {
+            return None;
+        }
         let cols = Self::COLUMNS;
         let total = self.items.len();
 
@@ -539,8 +752,12 @@ impl HistoryPage {
 
             let card_area = Rect::new(x, y, card_width, card_height);
             let is_selected = idx == self.selected;
+            let is_marked = self.items[idx]
+                .item
+                .history_key()
+                .is_some_and(|key| self.selected_keys.contains(&key));
 
-            self.render_history_card(frame, card_area, idx, is_selected, theme);
+            self.render_history_card(frame, card_area, idx, is_selected, is_marked, theme);
         }
 
         // Loading indicator at bottom
@@ -559,18 +776,21 @@ impl HistoryPage {
         area: Rect,
         idx: usize,
         is_selected: bool,
+        is_marked: bool,
         theme: &Theme,
     ) {
         let card = &mut self.items[idx];
 
         // Card border
-        let border_color = if is_selected {
+        let border_color = if is_marked {
+            theme.warning
+        } else if is_selected {
             theme.bilibili_pink
         } else {
             theme.border_subtle
         };
 
-        let block = Block::default()
+        let mut block = Block::default()
             .borders(Borders::ALL)
             .border_type(if is_selected {
                 BorderType::Thick
@@ -578,6 +798,14 @@ impl HistoryPage {
                 BorderType::Rounded
             })
             .border_style(Style::default().fg(border_color));
+        if is_marked {
+            block = block.title(Span::styled(
+                " ✓ 已选择 ",
+                Style::default()
+                    .fg(theme.warning)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -650,5 +878,172 @@ impl HistoryPage {
                 Paragraph::new(progress_text).style(Style::default().fg(theme.fg_secondary));
             frame.render_widget(progress_widget, info_chunks[2]);
         }
+    }
+
+    fn render_footer(&self, frame: &mut Frame, area: Rect, theme: &Theme, keys: &Keybindings) {
+        if self.mode == HistoryMode::Deleting || self.notice.is_some() {
+            let text = self.notice.as_deref().unwrap_or("正在删除所选历史记录...");
+            frame.render_widget(
+                Paragraph::new(text)
+                    .alignment(Alignment::Center)
+                    .style(Style::default().fg(theme.fg_secondary)),
+                area,
+            );
+            return;
+        }
+
+        let muted = Style::default().fg(theme.fg_secondary);
+        let accent = Style::default()
+            .fg(theme.fg_accent)
+            .add_modifier(Modifier::BOLD);
+        let help = Line::from(vec![
+            Span::styled(" [", muted),
+            Span::styled(keys.get_arrow_keys_display(), accent),
+            Span::styled("/", muted),
+            Span::styled(keys.get_nav_keys_display(), accent),
+            Span::styled("] 导航  [", muted),
+            Span::styled("Space", accent),
+            Span::styled("] 选择  [", muted),
+            Span::styled("Ctrl+A/Ctrl+R", accent),
+            Span::styled("] 全选/反选  [", muted),
+            Span::styled(
+                "d",
+                Style::default().fg(theme.info).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("] 删除  [", muted),
+            Span::styled(
+                &keys.confirm,
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("] 详情  [", muted),
+            Span::styled("Esc", accent),
+            Span::styled(format!("] 取消  已选 {}", self.selected_keys.len()), muted),
+        ]);
+        frame.render_widget(Paragraph::new(help).alignment(Alignment::Center), area);
+    }
+
+    fn render_delete_confirmation(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let width = area.width.min(52);
+        let height = area.height.min(7);
+        let popup = Rect::new(
+            area.x + area.width.saturating_sub(width) / 2,
+            area.y + area.height.saturating_sub(height) / 2,
+            width,
+            height,
+        );
+        frame.render_widget(Clear, popup);
+        let message = format!(
+            "确定删除 {} 条历史记录？\n\nEnter 确认 · Esc 返回选择",
+            self.selected_keys.len()
+        );
+        frame.render_widget(
+            Paragraph::new(message)
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(theme.fg_primary))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(theme.warning))
+                        .title(" 删除历史记录 "),
+                ),
+            popup,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn history_page() -> HistoryPage {
+        let data = serde_json::from_value(serde_json::json!({
+            "cursor": {"max": 0, "view_at": 0, "business": "", "ps": 20},
+            "tab": null,
+            "list": [
+                {"title": "video", "kid": 1, "history": {"oid": 1, "bvid": "BV1", "business": "archive"}},
+                {"title": "article", "kid": 2, "history": {"oid": 20, "business": "article"}},
+                {"title": "live", "kid": 3, "history": {"oid": 30, "business": "live"}}
+            ]
+        }))
+        .expect("history fixture");
+        let mut page = HistoryPage::new();
+        page.apply_history_init(data);
+        page
+    }
+
+    #[test]
+    fn selection_shortcuts_only_include_loaded_eligible_records() {
+        let keys = Keybindings::default();
+        let mut page = history_page();
+
+        page.handle_input_with_modifiers(KeyCode::Char(' '), KeyModifiers::NONE, &keys);
+        assert_eq!(page.selected, 1);
+        assert_eq!(page.selected_keys.len(), 1);
+        page.handle_input_with_modifiers(KeyCode::Esc, KeyModifiers::NONE, &keys);
+
+        page.handle_input_with_modifiers(KeyCode::Char('a'), KeyModifiers::CONTROL, &keys);
+        assert_eq!(page.selected_keys.len(), 2);
+        page.handle_input_with_modifiers(KeyCode::Char('r'), KeyModifiers::CONTROL, &keys);
+        assert!(page.selected_keys.is_empty());
+
+        page.selected = 2;
+        page.handle_input_with_modifiers(KeyCode::Char(' '), KeyModifiers::NONE, &keys);
+        assert!(page.selected_keys.is_empty());
+    }
+
+    #[test]
+    fn delete_without_selection_targets_the_hovered_record() {
+        let keys = Keybindings::default();
+        let mut page = history_page();
+        page.selected = 1;
+
+        page.handle_input_with_modifiers(KeyCode::Char('d'), KeyModifiers::NONE, &keys);
+
+        assert_eq!(page.mode, HistoryMode::ConfirmDelete);
+        assert_eq!(
+            page.selected_keys,
+            HashSet::from([HistoryKey {
+                business: "article".into(),
+                kid: 2,
+            }])
+        );
+    }
+
+    #[test]
+    fn delete_confirmation_escape_and_partial_result_preserve_failed_selection() {
+        let keys = Keybindings::default();
+        let mut page = history_page();
+        page.handle_input_with_modifiers(KeyCode::Char('a'), KeyModifiers::CONTROL, &keys);
+        page.handle_input_with_modifiers(KeyCode::Char('d'), KeyModifiers::NONE, &keys);
+        assert_eq!(page.mode, HistoryMode::ConfirmDelete);
+
+        page.handle_input_with_modifiers(KeyCode::Esc, KeyModifiers::NONE, &keys);
+        assert_eq!(page.mode, HistoryMode::Selecting);
+        assert_eq!(page.selected_keys.len(), 2);
+
+        page.handle_input_with_modifiers(KeyCode::Char('d'), KeyModifiers::NONE, &keys);
+        let action = page.handle_input_with_modifiers(KeyCode::Enter, KeyModifiers::NONE, &keys);
+        assert!(matches!(action, Some(AppAction::DeleteHistoryItems(_))));
+        assert_eq!(page.mode, HistoryMode::Deleting);
+
+        let video = HistoryKey {
+            business: "archive".into(),
+            kid: 1,
+        };
+        let article = HistoryKey {
+            business: "article".into(),
+            kid: 2,
+        };
+        page.apply_delete_result(vec![video], vec![(article.clone(), "denied".into())]);
+        assert_eq!(page.items.len(), 2);
+        assert!(page.selected_keys.contains(&article));
+        assert_eq!(page.mode, HistoryMode::Selecting);
+
+        page.handle_input_with_modifiers(KeyCode::Esc, KeyModifiers::NONE, &keys);
+        assert!(page.selected_keys.is_empty());
+        assert_eq!(page.mode, HistoryMode::Browse);
     }
 }

--- a/src/ui/home.rs
+++ b/src/ui/home.rs
@@ -1,6 +1,6 @@
 //! Homepage with video recommendations in a grid layout with cover images
 
-use super::{Component, SearchPage, Theme};
+use super::{Component, SearchPage, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::recommend::HomeFeed;
 use crate::api::recommend::VideoItem;
@@ -142,19 +142,28 @@ impl HomePage {
         }
 
         let notice = self.footer_notice.take();
-        let mut help = format!(
-            "[↑/↓] 选择视频  [{} / {}] 翻页  [←/→] 切换面板  [{}] 播放  [{}] 搜索  [{}] 刷新",
-            keys.page_up, keys.page_down, keys.confirm, keys.search_focus, keys.refresh
+        let mut help = shortcut_footer(
+            theme,
+            [
+                ("↑/↓".into(), "选择视频".into(), theme.fg_accent),
+                (
+                    format!("{} / {}", keys.page_up, keys.page_down),
+                    "翻页".into(),
+                    theme.fg_accent,
+                ),
+                ("←/→".into(), "切换面板".into(), theme.fg_accent),
+                (keys.confirm.clone(), "播放".into(), theme.success),
+                (keys.search_focus.clone(), "搜索".into(), theme.info),
+                (keys.refresh.clone(), "刷新".into(), theme.info),
+            ],
         );
         if let Some(notice) = notice {
-            help.push_str(&format!("  {notice}"));
+            help.spans.push(Span::styled(
+                format!("  {notice}"),
+                Style::default().fg(theme.fg_secondary),
+            ));
         }
-        frame.render_widget(
-            Paragraph::new(help)
-                .style(Style::default().fg(theme.fg_secondary))
-                .alignment(Alignment::Center),
-            chunks[2],
-        );
+        frame.render_widget(Paragraph::new(help).alignment(Alignment::Center), chunks[2]);
     }
 }
 

--- a/src/ui/live.rs
+++ b/src/ui/live.rs
@@ -1,6 +1,6 @@
 //! Live streaming recommendations page with grid layout
 
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::live::LiveRoom;
 use crate::application::AppAction;
@@ -383,65 +383,28 @@ impl Component for LivePage {
         self.render_grid(frame, chunks[1], theme);
 
         // Footer with hints
-        let nav_keys = keys.get_nav_keys_display();
-        let hints = Paragraph::new(Line::from(vec![
-            Span::styled(" [", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                format!("{}/↑↓←→", nav_keys),
-                Style::default()
-                    .fg(theme.fg_accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("] ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("导航", Style::default().fg(theme.fg_secondary)),
-            Span::styled("  [", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                format!("{}/{}", keys.page_up, keys.page_down),
-                Style::default()
-                    .fg(theme.fg_accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("] ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("翻页", Style::default().fg(theme.fg_secondary)),
-            Span::styled("  [", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                &keys.confirm,
-                Style::default()
-                    .fg(theme.success)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("/", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                &keys.play,
-                Style::default()
-                    .fg(theme.success)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("] ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("进入", Style::default().fg(theme.fg_secondary)),
-            Span::styled("  [", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                &keys.refresh,
-                Style::default()
-                    .fg(theme.warning)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("] ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("刷新", Style::default().fg(theme.fg_secondary)),
-            Span::styled("  [", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                &keys.next_theme,
-                Style::default().fg(theme.info).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("] ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("切换主题", Style::default().fg(theme.fg_secondary)),
-        ]))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(theme.border_subtle)),
-        )
+        let hints = Paragraph::new(shortcut_footer(
+            theme,
+            [
+                (
+                    format!("{}/↑↓←→", keys.get_nav_keys_display()),
+                    "导航".into(),
+                    theme.fg_accent,
+                ),
+                (
+                    format!("{}/{}", keys.page_up, keys.page_down),
+                    "翻页".into(),
+                    theme.fg_accent,
+                ),
+                (
+                    format!("{}/{}", keys.confirm, keys.play),
+                    "进入".into(),
+                    theme.success,
+                ),
+                (keys.refresh.clone(), "刷新".into(), theme.info),
+                (keys.next_theme.clone(), "切换主题".into(), theme.info),
+            ],
+        ))
         .alignment(Alignment::Center);
         frame.render_widget(hints, chunks[2]);
     }

--- a/src/ui/live_detail.rs
+++ b/src/ui/live_detail.rs
@@ -1,6 +1,6 @@
 //! Live streaming detail page with room info and real-time messages
 
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::live::LiveRoomInfo;
 use crate::api::live_danmaku_hub::LiveDanmakuHub;
@@ -344,21 +344,21 @@ impl LiveDetailPage {
         self.render_entry_panel(frame, right_chunks[1], theme);
 
         // Bottom hints
-        let hints = Paragraph::new(Line::from(vec![
-            Span::styled(
-                format!(" {}/", &keys.confirm),
-                Style::default().fg(theme.fg_accent),
-            ),
-            Span::styled(
-                format!("{} ", &keys.play),
-                Style::default().fg(theme.fg_accent),
-            ),
-            Span::styled("播放  ", Style::default().fg(theme.fg_secondary)),
-            Span::styled(&keys.back, Style::default().fg(theme.error)),
-            Span::styled("/", Style::default().fg(theme.fg_secondary)),
-            Span::styled(&keys.quit, Style::default().fg(theme.error)),
-            Span::styled(" 返回", Style::default().fg(theme.fg_secondary)),
-        ]))
+        let hints = Paragraph::new(shortcut_footer(
+            theme,
+            [
+                (
+                    format!("{}/{}", keys.confirm, keys.play),
+                    "播放".into(),
+                    theme.success,
+                ),
+                (
+                    format!("{}/{}", keys.back, keys.quit),
+                    "返回".into(),
+                    theme.info,
+                ),
+            ],
+        ))
         .alignment(Alignment::Center);
         frame.render_widget(hints, chunks[1]);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+mod article_detail;
 mod bangumi;
 mod bangumi_detail;
 mod dynamic;
@@ -16,6 +17,7 @@ mod up;
 mod video_card;
 mod video_detail;
 
+pub use article_detail::ArticleDetailPage;
 pub use bangumi::BangumiPage;
 pub use bangumi_detail::BangumiDetailPage;
 pub use dynamic::{DynamicPage, DynamicTab};
@@ -39,8 +41,32 @@ use crate::storage::Keybindings;
 use ratatui::{
     Frame,
     crossterm::event::{KeyCode, KeyModifiers, MouseEvent},
-    prelude::Rect,
+    prelude::{Color, Line, Modifier, Rect, Span, Style},
 };
+
+/// Build the centered, bracketed shortcut footer used across list pages.
+/// Each tuple is `(shortcut, label, color)`; shortcut text is emphasized while
+/// labels and brackets use the secondary foreground.
+pub fn shortcut_footer(
+    theme: &Theme,
+    items: impl IntoIterator<Item = (String, String, Color)>,
+) -> Line<'static> {
+    let muted = Style::default().fg(theme.fg_secondary);
+    let mut spans = Vec::new();
+    for (index, (shortcut, label, color)) in items.into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled("  ", muted));
+        }
+        spans.push(Span::styled("[", muted));
+        spans.push(Span::styled(
+            shortcut,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled("] ", muted));
+        spans.push(Span::styled(label, muted));
+    }
+    Line::from(spans)
+}
 
 /// UI Component trait
 pub trait Component {
@@ -71,6 +97,7 @@ pub enum Page {
     Search(SearchPage),
     Dynamic(DynamicPage),
     DynamicDetail(Box<DynamicDetailPage>),
+    ArticleDetail(Box<ArticleDetailPage>),
     VideoDetail(Box<VideoDetailPage>),
     Up(Box<UpPage>),
     History(HistoryPage),

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,7 +1,7 @@
 //! Search page with video card grid display
 
 use super::video_card::{VideoCard, VideoCardGrid};
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::search::{HotwordItem, SearchVideoItem};
 use crate::application::AppAction;
@@ -370,26 +370,40 @@ impl Component for SearchPage {
         }
 
         // Help
-        let help_text = if self.input_mode {
-            format!(
-                "[{}] 搜索  [{}] 取消  [{}] 导航",
-                keys.confirm, keys.back, keys.nav_next_page
+        let help = if self.input_mode {
+            shortcut_footer(
+                theme,
+                [
+                    (keys.confirm.clone(), "搜索".into(), theme.success),
+                    (keys.back.clone(), "取消".into(), theme.info),
+                    (keys.nav_next_page.clone(), "导航".into(), theme.fg_accent),
+                ],
             )
         } else {
-            format!(
-                "[{}/{}] 导航  [{}/{}] 翻页  [{}] 详情  [{}] 搜索  [{}] 切换",
-                keys.get_arrow_keys_display(),
-                keys.get_nav_keys_display(),
-                keys.page_up,
-                keys.page_down,
-                keys.confirm,
-                keys.search_focus,
-                keys.nav_next_page
+            shortcut_footer(
+                theme,
+                [
+                    (
+                        format!(
+                            "{}/{}",
+                            keys.get_arrow_keys_display(),
+                            keys.get_nav_keys_display()
+                        ),
+                        "导航".into(),
+                        theme.fg_accent,
+                    ),
+                    (
+                        format!("{}/{}", keys.page_up, keys.page_down),
+                        "翻页".into(),
+                        theme.fg_accent,
+                    ),
+                    (keys.confirm.clone(), "详情".into(), theme.success),
+                    (keys.search_focus.clone(), "搜索".into(), theme.info),
+                    (keys.nav_next_page.clone(), "切换".into(), theme.info),
+                ],
             )
         };
-        let help = Paragraph::new(help_text)
-            .style(Style::default().fg(theme.fg_secondary))
-            .alignment(Alignment::Center);
+        let help = Paragraph::new(help).alignment(Alignment::Center);
         frame.render_widget(help, chunks[2]);
     }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -2,7 +2,7 @@
 
 use super::{Component, DEFAULT_THEME_ID, Theme, ThemeChoice};
 use crate::application::AppAction;
-use crate::storage::{DanmakuConfig, Keybindings};
+use crate::storage::{DanmakuConfig, Keybindings, VideoQuality};
 use ratatui::{crossterm::event::KeyCode, prelude::*, widgets::*};
 
 /// Settings sections
@@ -41,6 +41,7 @@ pub struct SettingsPage {
     pub current_section: SettingsSection,
     pub selected_theme_index: usize,
     pub selected_danmaku_index: usize,
+    pub selected_playback_index: usize,
     pub selected_keybind_index: usize,
     pub keybindings: Keybindings,
     pub current_theme_id: String,
@@ -48,6 +49,7 @@ pub struct SettingsPage {
     pub is_logged_in: bool,
     pub danmaku: DanmakuConfig,
     pub auto_play: bool,
+    pub video_quality: VideoQuality,
     section_index: usize,
     pub editing_keybind: bool,
     editing_danmaku: bool,
@@ -61,6 +63,7 @@ impl SettingsPage {
         is_logged_in: bool,
         danmaku: DanmakuConfig,
         auto_play: bool,
+        video_quality: VideoQuality,
     ) -> Self {
         let theme_choices = Theme::available_theme_choices();
         let theme_index = theme_choices
@@ -72,6 +75,7 @@ impl SettingsPage {
             current_section: SettingsSection::Theme,
             selected_theme_index: theme_index,
             selected_danmaku_index: 0,
+            selected_playback_index: 0,
             selected_keybind_index: 0,
             keybindings,
             current_theme_id: theme_id,
@@ -79,6 +83,7 @@ impl SettingsPage {
             is_logged_in,
             danmaku,
             auto_play,
+            video_quality,
             section_index: 0,
             editing_keybind: false,
             editing_danmaku: false,
@@ -131,6 +136,7 @@ impl Default for SettingsPage {
             false,
             DanmakuConfig::default(),
             true,
+            VideoQuality::Best,
         )
     }
 }
@@ -314,6 +320,11 @@ impl Component for SettingsPage {
             self.current_section = sections[self.section_index];
             return Some(AppAction::None);
         }
+        if (keys.matches_left(key) || keys.matches_right(key))
+            && self.current_section == SettingsSection::Playback
+        {
+            return Some(self.adjust_playback(if keys.matches_right(key) { 1 } else { -1 }));
+        }
         if keys.matches_left(key) || keys.matches_right(key) {
             self.change_section(if keys.matches_right(key) { 1 } else { -1 });
             return Some(AppAction::None);
@@ -333,7 +344,10 @@ impl Component for SettingsPage {
                 SettingsSection::Danmaku => {
                     self.selected_danmaku_index = self.selected_danmaku_index.saturating_sub(1);
                 }
-                SettingsSection::Playback | SettingsSection::Account => {}
+                SettingsSection::Playback => {
+                    self.selected_playback_index = self.selected_playback_index.saturating_sub(1);
+                }
+                SettingsSection::Account => {}
             }
             return Some(AppAction::None);
         }
@@ -355,7 +369,10 @@ impl Component for SettingsPage {
                     self.selected_danmaku_index =
                         (self.selected_danmaku_index + 1).min(Self::DANMAKU_ROWS - 1);
                 }
-                SettingsSection::Playback | SettingsSection::Account => {}
+                SettingsSection::Playback => {
+                    self.selected_playback_index = (self.selected_playback_index + 1).min(1);
+                }
+                SettingsSection::Account => {}
             }
             return Some(AppAction::None);
         }
@@ -383,8 +400,7 @@ impl Component for SettingsPage {
                     self.editing_danmaku = true;
                 }
                 SettingsSection::Playback => {
-                    self.auto_play = !self.auto_play;
-                    return Some(AppAction::SaveAutoPlay(self.auto_play));
+                    return Some(self.adjust_playback(1));
                 }
                 SettingsSection::Keybindings => {
                     // Enter keybind editing mode
@@ -402,6 +418,19 @@ impl Component for SettingsPage {
 
 impl SettingsPage {
     const DANMAKU_ROWS: usize = 9;
+
+    fn adjust_playback(&mut self, direction: i32) -> AppAction {
+        match self.selected_playback_index {
+            0 => {
+                self.auto_play = !self.auto_play;
+                AppAction::SaveAutoPlay(self.auto_play)
+            }
+            _ => {
+                self.video_quality = self.video_quality.cycle(direction);
+                AppAction::SaveVideoQuality(self.video_quality)
+            }
+        }
+    }
 
     fn change_section(&mut self, direction: i32) {
         let sections = SettingsSection::all();
@@ -596,28 +625,38 @@ impl SettingsPage {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let value_str = if self.auto_play { "开启" } else { "关闭" };
-        let row = format!("▶ 进入视频自动播放：{value_str}");
-        let hint = "  按 Enter 切换";
+        let rows = [
+            format!(
+                "进入视频自动播放：{}",
+                if self.auto_play { "开启" } else { "关闭" }
+            ),
+            format!("默认视频画质：{}", self.video_quality.label()),
+        ];
 
         let chunks = Layout::vertical([
-            Constraint::Length(1),
+            Constraint::Length(2),
             Constraint::Length(1),
             Constraint::Min(0),
         ])
         .split(inner);
 
+        let items = rows.into_iter().enumerate().map(|(index, row)| {
+            let selected = index == self.selected_playback_index;
+            ListItem::new(format!("{}{}", if selected { "▶ " } else { "  " }, row)).style(
+                if selected {
+                    Style::default()
+                        .fg(theme.fg_primary)
+                        .bg(theme.selection_bg)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.fg_secondary)
+                },
+            )
+        });
+        frame.render_widget(List::new(items), chunks[0]);
         frame.render_widget(
-            Paragraph::new(row).style(
-                Style::default()
-                    .fg(theme.fg_primary)
-                    .bg(theme.selection_bg)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            chunks[0],
-        );
-        frame.render_widget(
-            Paragraph::new(hint).style(Style::default().fg(theme.fg_secondary)),
+            Paragraph::new("  按 ←/→ 或 Enter 更改并立即保存")
+                .style(Style::default().fg(theme.fg_secondary)),
             chunks[1],
         );
     }
@@ -865,5 +904,26 @@ mod tests {
         page.handle_input(KeyCode::Esc, &keys);
         assert!(!page.editing_keybind);
         assert_eq!(page.keybindings.quit, original);
+    }
+
+    #[test]
+    fn playback_rows_save_auto_play_and_quality_immediately() {
+        let keys = Keybindings::default();
+        let mut page = SettingsPage {
+            current_section: SettingsSection::Playback,
+            section_index: 2,
+            ..SettingsPage::default()
+        };
+
+        let action = page.handle_input(KeyCode::Enter, &keys);
+        assert!(matches!(action, Some(AppAction::SaveAutoPlay(false))));
+
+        page.handle_input(KeyCode::Char('j'), &keys);
+        let action = page.handle_input(KeyCode::Char('l'), &keys);
+        assert_eq!(page.video_quality, VideoQuality::Q4k);
+        assert!(matches!(
+            action,
+            Some(AppAction::SaveVideoQuality(VideoQuality::Q4k))
+        ));
     }
 }

--- a/src/ui/up.rs
+++ b/src/ui/up.rs
@@ -1,4 +1,4 @@
-use super::{Component, Theme, VideoCard, VideoCardGrid};
+use super::{Component, Theme, VideoCard, VideoCardGrid, shortcut_footer};
 use crate::api::{
     favorite::{FavoriteFolder, FavoriteOrder, FavoriteResourceData},
     space::{RelationStat, SpaceInfo, SpaceVideoData, SpaceVideoOrder},
@@ -9,7 +9,7 @@ use crate::storage::Keybindings;
 use ratatui::{
     Frame,
     crossterm::event::KeyCode,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Tabs, Wrap},
@@ -291,13 +291,23 @@ impl Component for UpPage {
         }
 
         frame.render_widget(
-            Paragraph::new(format!(
-                "[1/2] 投稿/收藏夹  [{}/{}] 翻页  [o] 最新/热门  [s] 顺序/倒序/随机  [{}] 连播  [Enter] 打开  [{}] 返回",
-                keys.page_up,
-                keys.page_down,
-                keys.play,
-                keys.back
-            )),
+            Paragraph::new(shortcut_footer(
+                theme,
+                [
+                    ("1/2".into(), "投稿/收藏夹".into(), theme.info),
+                    (
+                        format!("{}/{}", keys.page_up, keys.page_down),
+                        "翻页".into(),
+                        theme.fg_accent,
+                    ),
+                    ("o".into(), "最新/热门".into(), theme.info),
+                    ("s".into(), "顺序/倒序/随机".into(), theme.info),
+                    (keys.play.clone(), "连播".into(), theme.success),
+                    (keys.confirm.clone(), "打开".into(), theme.success),
+                    (keys.back.clone(), "返回".into(), theme.info),
+                ],
+            ))
+            .alignment(Alignment::Center),
             chunks[3],
         );
     }

--- a/src/ui/video_detail.rs
+++ b/src/ui/video_detail.rs
@@ -1,7 +1,7 @@
 //! Video detail page showing video info, comments, and related videos
 
 use super::video_card::{VideoCard, VideoCardGrid};
-use super::{Component, Theme};
+use super::{Component, Theme, shortcut_footer};
 use crate::api::client::ApiClient;
 use crate::api::comment::CommentItem;
 use crate::api::video::{RelatedVideoItem, VideoInfo};
@@ -728,24 +728,33 @@ impl Component for VideoDetailPage {
         } else {
             chunks[2]
         };
-        let help_text = if self.input_mode {
-            format!("[{}] 发送评论  [{}] 取消", keys.confirm, keys.back)
+        let help = if self.input_mode {
+            shortcut_footer(
+                theme,
+                [
+                    (keys.confirm.clone(), "发送评论".into(), theme.success),
+                    (keys.back.clone(), "取消".into(), theme.info),
+                ],
+            )
         } else {
-            format!(
-                "[{}/{}] 滚动  [{}] 切换  [{}] 点赞/选择  [{}] 评论  [{}] 回复  [{}] 播放  [{}] 返回",
-                keys.nav_up,
-                keys.nav_down,
-                keys.nav_next_page,
-                keys.confirm,
-                keys.comment,
-                keys.toggle_replies,
-                keys.play,
-                keys.back
+            shortcut_footer(
+                theme,
+                [
+                    (
+                        format!("{}/{}", keys.nav_up, keys.nav_down),
+                        "滚动".into(),
+                        theme.fg_accent,
+                    ),
+                    (keys.nav_next_page.clone(), "切换".into(), theme.info),
+                    (keys.confirm.clone(), "点赞/选择".into(), theme.success),
+                    (keys.comment.clone(), "评论".into(), theme.info),
+                    (keys.toggle_replies.clone(), "回复".into(), theme.info),
+                    (keys.play.clone(), "播放".into(), theme.success),
+                    (keys.back.clone(), "返回".into(), theme.info),
+                ],
             )
         };
-        let help = Paragraph::new(help_text)
-            .style(Style::default().fg(theme.fg_secondary))
-            .alignment(Alignment::Center);
+        let help = Paragraph::new(help).alignment(Alignment::Center);
         frame.render_widget(help, help_chunk);
     }
 


### PR DESCRIPTION
## Summary

- Add multi-selection and deletion for eligible history records.
- Support direct `d` deletion prompts and automatic cursor advancement after selection.
- Fix PGC/VIP playback from history using exact episode IDs.
- Add persisted default video quality settings.
- Add an article reader with ordered inline images and a comments column.
- Standardize shortcut footers across pages to match with the same layout.

## Validation

- `cargo fmt --check`
- `cargo test` — 79 passed, 4 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`

## Summary by Sourcery

Add history management, article reading, and persistent video quality controls, while improving playback routing and unifying shortcut footers across the UI.

New Features:
- Add multi-select, bulk delete, and keyboard-driven workflow for video and article history entries.
- Introduce an article reader page with inline images, normalized text layout, and a comments sidebar.
- Add configurable default video quality in settings and apply it to video, playlist, and bangumi playback, including PGC history playback.

Enhancements:
- Improve history item routing to correctly open archive videos, bangumi episodes, and articles from history.
- Persist and expose video quality preference in app config and wire it through API client, CDN ranking, and player commands.
- Standardize shortcut/help footers across major UI pages using a shared footer builder for consistent layout and styling.
- Ensure history cover downloads and article image downloads are generation-safe and cleaned up after deletions or navigation.

Tests:
- Add unit tests covering history selection and deletion behavior, article routing and document parsing, video quality serialization, CDN stream selection caps, and bangumi/history auto-play.
- Extend network and API contract tests for bangumi playurl parsing and history/article workflows.